### PR TITLE
Rwd/split refactor

### DIFF
--- a/stack.ghc-8.2.2.yaml
+++ b/stack.ghc-8.2.2.yaml
@@ -7,6 +7,7 @@ packages:
 - x86
 - symbolic
 - x86_symbolic
+- deps/crucible/what4
 - deps/crucible/crucible
 - deps/crucible/crucible-llvm
 - deps/dwarf

--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -13,6 +13,7 @@ library
     ansi-wl-pprint,
     containers,
     crucible >= 0.3.2,
+    what4 >= 0.4,
     lens,
     macaw-base,
     mtl,

--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -50,21 +50,24 @@ import           Data.Parameterized.Context as Ctx
 --import qualified Data.Set as Set
 --import qualified Data.Text as Text
 import           Data.Word
+
+import qualified What4.FunctionName as C
+import           What4.Interface
+import qualified What4.ProgramLoc as C
+import           What4.Symbol(userSymbol)
+
 import qualified Lang.Crucible.Analysis.Postdom as C
+import           Lang.Crucible.Backend
 import qualified Lang.Crucible.CFG.Core as C
 import qualified Lang.Crucible.CFG.Reg as CR
 import qualified Lang.Crucible.CFG.SSAConversion as C
 import qualified Lang.Crucible.FunctionHandle as C
-import qualified Lang.Crucible.FunctionName as C
-import qualified Lang.Crucible.ProgramLoc as C
 import qualified Lang.Crucible.Simulator.ExecutionTree as C
 import qualified Lang.Crucible.Simulator.Intrinsics as C
 import qualified Lang.Crucible.Simulator.GlobalState as C
 import qualified Lang.Crucible.Simulator.OverrideSim as C
 import qualified Lang.Crucible.Simulator.RegMap as C
-import           Lang.Crucible.Solver.BoolInterface
-import           Lang.Crucible.Solver.Interface
-import           Lang.Crucible.Solver.Symbol(userSymbol)
+
 import           System.IO (stdout)
 
 import qualified Lang.Crucible.LLVM.MemModel as MM

--- a/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
@@ -79,14 +79,15 @@ import qualified Data.Parameterized.TH.GADT as U
 import           Data.Proxy
 
 
+import           What4.ProgramLoc as C
+import qualified What4.Symbol as C
+
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Data.Word
 import qualified Lang.Crucible.CFG.Expr as C
 import qualified Lang.Crucible.CFG.Reg as CR
-import           Lang.Crucible.ProgramLoc as C
-import qualified Lang.Crucible.Solver.Symbol as C
 import qualified Lang.Crucible.Types as C
 
 import qualified Lang.Crucible.LLVM.MemModel as MM

--- a/x86_symbolic/macaw-x86-symbolic.cabal
+++ b/x86_symbolic/macaw-x86-symbolic.cabal
@@ -39,6 +39,7 @@ test-suite macaw-x86-symbolic-tests
     bytestring,
     containers,
     crucible,
+    crucible-llvm,
     elf-edit,
     macaw-base,
     macaw-symbolic,

--- a/x86_symbolic/macaw-x86-symbolic.cabal
+++ b/x86_symbolic/macaw-x86-symbolic.cabal
@@ -17,6 +17,7 @@ library
                  mtl,
                  parameterized-utils,
                  crucible-llvm,
+                 what4 >= 0.4,
                  lens
   hs-source-dirs: src
 
@@ -45,4 +46,5 @@ test-suite macaw-x86-symbolic-tests
     macaw-x86-symbolic,
     parameterized-utils,
     text,
+    what4,
     vector

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -39,22 +39,23 @@ import Data.Word(Word8)
 import Data.Bits(shiftL,testBit)
 import GHC.TypeLits(KnownNat)
 
+import           What4.Interface hiding (IsExpr)
+import           What4.Symbol(userSymbol)
+import           What4.Utils.Endian(Endian(..))
+
+import           Lang.Crucible.Backend (IsSymInterface)
+import           Lang.Crucible.CFG.Expr
 import           Lang.Crucible.Simulator.ExecutionTree
 import           Lang.Crucible.Simulator.RegMap
 import qualified Lang.Crucible.Simulator.Evaluation as C
 import           Lang.Crucible.Simulator.Intrinsics(IntrinsicTypes)
 import           Lang.Crucible.Syntax
-import           Lang.Crucible.CFG.Expr
-import           Lang.Crucible.Solver.BoolInterface (IsSymInterface)
-import           Lang.Crucible.Solver.Interface hiding (IsExpr)
-import           Lang.Crucible.Solver.Symbol(userSymbol)
 import           Lang.Crucible.Types
 import qualified Lang.Crucible.Vector as V
-import           Lang.Crucible.Utils.Endian(Endian(..))
+
 import           Lang.Crucible.LLVM.MemModel (LLVMPointerType)
 import Lang.Crucible.LLVM.MemModel.Pointer
   (projectLLVM_bv, pattern LLVMPointerRepr, llvmPointer_bv)
-
 
 import qualified Data.Macaw.Types as M
 import           Data.Macaw.Symbolic.CrucGen(MacawExt)

--- a/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
@@ -47,14 +47,13 @@ import qualified Data.Macaw.X86.X86Reg as M
 import           Data.Macaw.X86.Crucible
 import qualified Flexdis86.Register as F
 
+import qualified What4.Symbol as C
+
+import qualified Lang.Crucible.Backend as C
 import qualified Lang.Crucible.CFG.Extension as C
 import qualified Lang.Crucible.CFG.Reg as C
 import qualified Lang.Crucible.Types as C
-import qualified Lang.Crucible.Solver.Symbol as C
-import qualified Lang.Crucible.Solver.BoolInterface as C
 import Lang.Crucible.Simulator.RegValue(RegValue'(..))
-
-
 
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Fixup due to Crucible refactoring.  This mostly involves fixing up module imports.

Note, the x86_symbolic test suite currently fails to compile for reasons that appear unrelated to the crucible refactoring.  I've fixed issues that seem related to my changes, and left the test module in a broken state, as I'm not sure what the proper fixes are. 