### PR TITLE
Change an error call to a safe failure

### DIFF
--- a/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
+++ b/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
@@ -127,7 +127,7 @@ addUpperBound :: ( MapF.OrdF (ArchReg arch)
 addUpperBound v u bnds
     -- Do nothing if upper bounds equals or exceeds function
   | u >= maxUnsigned (typeWidth v) = Right bnds
-  | u < 0 = error "addUpperBound given negative value."
+  | u < 0 = Left "addUpperBound given negative value."
   | otherwise =
   case v of
     BVValue _ c | c <= u -> Right bnds


### PR DESCRIPTION
@dmwit - I have a large collection of binaries that trigger this error condition consistently (I can send them to you).  Is it safe to just have this be a `Left` instead of a call to error?  I assume so, but want to check.