### PR TITLE
Memory examples

### DIFF
--- a/symbolic/examples/memory.hs
+++ b/symbolic/examples/memory.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 import           GHC.TypeLits
 import           Control.Monad.ST ( stToIO, RealWorld )
@@ -59,3 +60,6 @@ useCFG hdlAlloc sym MS.ArchVals { MS.withArchEval = withArchEval }
   case execRes of
     CS.FinishedResult {} -> return ()
     _ -> putStrLn "Simulation failed"
+
+main :: IO ()
+main = return ()

--- a/symbolic/examples/memory.hs
+++ b/symbolic/examples/memory.hs
@@ -50,7 +50,8 @@ useCFG hdlAlloc sym MS.ArchVals { MS.withArchEval = withArchEval }
   let rep = CFH.handleReturnType (CC.cfgHandle cfg)
   memModelVar <- stToIO (CLM.mkMemVar hdlAlloc)
   (initialMem, memPtrTbl) <- MSM.newGlobalMemory (Proxy @arch) sym LDL.LittleEndian MSM.SymbolicMutable mem
-  let extImpl = MS.macawExtensions archEvalFns memModelVar (MSM.mapRegionPointers memPtrTbl) lfh
+  mapping <- MSM.mapRegionPointers memPtrTbl <$> CLM.mkNullPointer sym WI.knownNat
+  let extImpl = MS.macawExtensions archEvalFns memModelVar mapping lfh
   let simCtx = CS.initSimContext sym CLI.llvmIntrinsicTypes hdlAlloc IO.stderr CFH.emptyHandleMap extImpl MS.MacawSimulatorState
   let simGlobalState = CSG.insertGlobal memModelVar initialMem CS.emptyGlobals
   let simulation = CS.regValue <$> CS.callCFG cfg initialRegs

--- a/symbolic/examples/simulation.hs
+++ b/symbolic/examples/simulation.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
 import           Control.Monad.ST ( stToIO, RealWorld )
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Symbolic as MS
@@ -43,3 +45,6 @@ useCFG hdlAlloc sym MS.ArchVals { MS.withArchEval = withArchEval }
   case execRes of
     CS.FinishedResult {} -> return ()
     _ -> putStrLn "Simulation failed"
+
+main :: IO ()
+main = return ()

--- a/symbolic/examples/translation.hs
+++ b/symbolic/examples/translation.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
 import           Control.Monad.ST ( stToIO )
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as MD
@@ -31,3 +33,6 @@ translate dfi =
 
 useCFG :: CC.SomeCFG (MS.MacawExt arch) (MS.MacawFunctionArgs arch) (MS.MacawFunctionResult arch) -> IO ()
 useCFG _ = return ()
+
+main :: IO ()
+main = return ()

--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -52,3 +52,27 @@ executable memory-example
                , what4
   ghc-options:      -Wall -Wcompat -Werror
   default-language: Haskell2010
+
+executable simulation-example
+  main-is: examples/simulation.hs
+  build-depends: base
+               , crucible
+               , crucible-llvm
+               , macaw-base
+               , macaw-symbolic
+               , what4
+  ghc-options:      -Wall -Wcompat -Werror
+  default-language: Haskell2010
+
+executable translation-example
+  main-is: examples/translation.hs
+  build-depends: base
+               , containers
+               , crucible
+               , crucible-llvm
+               , macaw-base
+               , macaw-symbolic
+               , text
+               , what4
+  ghc-options:      -Wall -Wcompat -Werror
+  default-language: Haskell2010

--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -41,3 +41,14 @@ library
 
   if impl(ghc >= 8.6)
     default-extensions: NoStarIsType
+
+executable memory-example
+  main-is: examples/memory.hs
+  build-depends: base
+               , crucible
+               , crucible-llvm
+               , macaw-base
+               , macaw-symbolic
+               , what4
+  ghc-options:      -Wall -Wcompat -Werror
+  default-language: Haskell2010

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -347,7 +347,9 @@ mapRegionPointers :: ( MC.MemWidth w
                      , CB.IsSymInterface sym
                      )
                   => MemPtrTable sym w
-                  -> CL.LLVMPtr sym w
+                  -> CL.LLVMPtr sym w  -- ^ default (i.e. null)
+                                       -- pointer value to return when
+                                       -- a mapping does not exist.
                   -> MS.GlobalMap sym w
 mapRegionPointers mpt default_ptr = \sym mem regionNum offsetVal ->
   case WI.asNat regionNum of
@@ -372,7 +374,7 @@ mapBitvectorToLLVMPointer :: ( MC.MemWidth w
                           -> sym
                           -> CS.RegValue sym CL.Mem
                           -> CS.RegValue sym (CT.BVType w)
-                          -> CL.LLVMPtr sym w
+                          -> CL.LLVMPtr sym w  -- ^ "null pointer" value if no valid mapping
                           -> IO (Maybe (CL.LLVMPtr sym w))
 mapBitvectorToLLVMPointer mpt@(MemPtrTable im _) sym mem offsetVal default_ptr =
   case WI.asUnsignedBV offsetVal of
@@ -417,8 +419,9 @@ mapBitvectorToLLVMPointer mpt@(MemPtrTable im _) sym mem offsetVal default_ptr =
 --
 -- > "If addrStart <= O <= addrEnd, map O into that region"
 --
--- If the offset is not in any region, the pointer is mapped to the null pointer
--- to trigger an error (if it is used).
+-- If the offset is not in any region, the pointer is mapped to the
+-- default pointer (expected to be the null pointer) to trigger an
+-- error (if it is used).
 staticRegionMuxTree :: ( CB.IsSymInterface sym
                        , MC.MemWidth w
                        , 16 <= w


### PR DESCRIPTION
Adds builds of the example programs to the cabal file to ensure that the examples remain up-to-date.
Also fixes the memory example for the additional argument to `mapRegionPointers`.