### PR TITLE
Remove an unused parameter from macaw-symbolic

### DIFF
--- a/x86_symbolic/tests/Main.hs
+++ b/x86_symbolic/tests/Main.hs
@@ -95,11 +95,6 @@ main = do
       [] -> fail "Could not find add function"
       _ -> fail "Found multiple add functions"
 
-  memBaseVar <- C.freshGlobalVar halloc "add_mem_base" C.knownRepr
-
-  let memBaseVarMap :: MS.MemSegmentMap 64
-      memBaseVarMap = Map.singleton 1 memBaseVar
-
   let addrSymMap :: M.AddrSymMap 64
       addrSymMap = Map.fromList [ (Elf.memSymbolStart msym, Elf.memSymbolName msym)
                                 | msym <- nameAddrList ]
@@ -113,7 +108,7 @@ main = do
         putStrLn $ "Analyzing " ++ show addr
 
   (_, Some funInfo) <- stToIO $ M.analyzeFunction logFn addAddr M.UserRequest ds0
-  C.SomeCFG g <- MS.mkFunCFG x86ArchFns halloc memBaseVarMap "add" posFn funInfo
+  C.SomeCFG g <- MS.mkFunCFG x86ArchFns halloc "add" posFn funInfo
 
   regs <- MS.macawAssignToCrucM (mkReg x86ArchFns sym) (MS.crucGenRegAssignment x86ArchFns)
 


### PR DESCRIPTION
Most of the interface functions took a map from addresses to segments, however this map
was never actually used in macaw-symbolic.

The migration for this change is simply to remove the unused parameter from all
call sites in client code.