### PR TITLE
AbsVal/x86 cleanups

### DIFF
--- a/base/src/Data/Macaw/CFG/AssignRhs.hs
+++ b/base/src/Data/Macaw/CFG/AssignRhs.hs
@@ -28,19 +28,15 @@ module Data.Macaw.CFG.AssignRhs
   ) where
 
 import qualified Data.Kind as Kind
-import Data.Macaw.CFG.App
-import Data.Macaw.Memory (Endianness(..), MemSegmentOff, MemWord, MemAddr)
-import Data.Macaw.Types
-
-import Data.Monoid
-import Data.Parameterized.Classes
-import Data.Parameterized.NatRepr
-import Data.Parameterized.TraversableFC (FoldableFC(..))
-import Data.Proxy
-import Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
-
-import Prelude
-
+import           Data.Macaw.CFG.App
+import           Data.Macaw.Memory (Endianness(..), MemSegmentOff, MemWord, MemAddr)
+import           Data.Macaw.Types
+import           Data.Parameterized.Classes
+import           Data.Parameterized.NatRepr
+import           Data.Parameterized.TraversableFC (FoldableFC(..))
+import           Data.Proxy
+import           Numeric.Natural
+import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>), (<>))
 
 -- | Width of register used to store addresses.
 type family RegAddrWidth (r :: Type -> Kind.Type) :: Nat
@@ -58,11 +54,14 @@ type family ArchReg (arch :: Kind.Type) = (reg :: Type -> Kind.Type) | reg -> ar
 
 -- | A type family for architecture specific functions.
 --
--- These functions may return a value.  They may depend on the current state of
--- the heap, but should not affect the processor state.
+-- The functions associated with architecture-function depend on the
+-- contents of memory and implicit components of the processor state,
+-- but they should not affect any of the architecture registers in
+-- @ArchReg arch@.  They may only depend on the value stored in a
+-- general purpose register if it is passed as a value that can be
+-- visited when folding over values.  In particular,
 --
--- The function may depend on the set of registers defined so far, and the type
--- of the result.
+-- One Furthermore, they can only return a value
 type family ArchFn (arch :: Kind.Type) = (fn :: (Type -> Kind.Type) -> Type -> Kind.Type) | fn -> arch
 
 -- | A type family for defining architecture-specific statements.
@@ -125,10 +124,10 @@ instance Show (MemRepr tp) where
   show = show . pretty
 
 -- | Return the number of bytes this uses in memory.
-memReprBytes :: MemRepr tp -> Integer
-memReprBytes (BVMemRepr x _) = intValue x
-memReprBytes (FloatMemRepr f _) = intValue (floatInfoBytes f)
-memReprBytes (PackedVecMemRepr w r) = intValue w * memReprBytes r
+memReprBytes :: MemRepr tp -> Natural
+memReprBytes (BVMemRepr x _) = natValue x
+memReprBytes (FloatMemRepr f _) = natValue (floatInfoBytes f)
+memReprBytes (PackedVecMemRepr w r) = natValue w * memReprBytes r
 
 instance TestEquality MemRepr where
   testEquality (BVMemRepr xw xe) (BVMemRepr yw ye) = do

--- a/base/src/Data/Macaw/Discovery/AbsEval.hs
+++ b/base/src/Data/Macaw/Discovery/AbsEval.hs
@@ -32,7 +32,7 @@ absEvalReadMem :: RegisterInfo (ArchReg a)
 absEvalReadMem r a tp
     -- If the value is a stack entry, then see if there is a stack
     -- value associated with it.
-  | StackOffset _ o <- transferValue r a
+  | StackOffsetAbsVal _ o <- transferValue r a
   , Just (StackEntry v_tp v) <- Map.lookup o (r^.curAbsStack)
   , Just Refl <- testEquality tp v_tp = v
   | otherwise = TopV

--- a/base/src/Data/Macaw/Memory.hs
+++ b/base/src/Data/Macaw/Memory.hs
@@ -51,6 +51,7 @@ module Data.Macaw.Memory
   , SplitError(..)
     -- * MemWidth
   , MemWidth(..)
+  , memWidthNatRepr
     -- * MemWord
   , MemWord
   , memWord
@@ -334,6 +335,9 @@ class (1 <= w) => MemWidth w where
 
   -- | Rotates the value by the given index.
   addrRotate :: MemWord w -> Int -> MemWord w
+
+memWidthNatRepr :: MemWidth w => NatRepr w
+memWidthNatRepr = addrWidthNatRepr (addrWidthRepr memWidthNatRepr)
 
 -- | Read an address with the given endianess.
 --

--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -343,6 +343,7 @@ transferAbsValue r f =
     ReadLoc _  -> TopV
     ReadFSBase -> TopV
     ReadGSBase -> TopV
+    GetSegmentSelector _ -> TopV
     CPUID _    -> TopV
     CMPXCHG8B{} -> TopV
     RDTSC      -> TopV

--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -340,7 +340,6 @@ transferAbsValue :: AbsProcessorState X86Reg ids
 transferAbsValue r f =
   case f of
     EvenParity _ -> TopV
-    ReadLoc _  -> TopV
     ReadFSBase -> TopV
     ReadGSBase -> TopV
     GetSegmentSelector _ -> TopV

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -139,8 +139,7 @@ instance PrettyF X86TermStmt where
 --  X86 architecture model.
 -- Primitive locations are not modeled as registers, but rather as implicit state.
 data X86PrimLoc tp
-   = (tp ~ BVType 64) => DebugLoc   !F.DebugReg
-   | (tp ~ BVType 16) => FS
+   = (tp ~ BVType 16) => FS
      -- ^ This refers to the selector of the 'FS' register.
    | (tp ~ BVType 16) => GS
      -- ^ This refers to the selector of the 'GS' register.
@@ -148,7 +147,6 @@ data X86PrimLoc tp
      -- ^ One of the x87 control registers
 
 instance HasRepr X86PrimLoc TypeRepr where
-  typeRepr DebugLoc{}   = knownRepr
   typeRepr FS = knownRepr
   typeRepr GS = knownRepr
   typeRepr (X87_ControlLoc r) =
@@ -156,7 +154,6 @@ instance HasRepr X86PrimLoc TypeRepr where
       LeqProof -> BVTypeRepr (typeRepr r)
 
 instance Pretty (X86PrimLoc tp) where
-  pretty (DebugLoc r) = text (show r)
   pretty FS = text "fs"
   pretty GS = text "gs"
   pretty (X87_ControlLoc r) = text (show r)

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -130,12 +130,16 @@ instance PrettyF X86TermStmt where
 ------------------------------------------------------------------------
 -- X86PrimLoc
 
--- | This describes a primitive location that can be read or written to in the
+-- | This describes a mutable component of the processor state which
+-- due to side effects and access checks is not modeled as a general
+-- purpose register.
+--
+
+-- primitive location that can be read or written to in the
 --  X86 architecture model.
 -- Primitive locations are not modeled as registers, but rather as implicit state.
 data X86PrimLoc tp
-   = (tp ~ BVType 64) => ControlLoc !F.ControlReg
-   | (tp ~ BVType 64) => DebugLoc   !F.DebugReg
+   = (tp ~ BVType 64) => DebugLoc   !F.DebugReg
    | (tp ~ BVType 16) => FS
      -- ^ This refers to the selector of the 'FS' register.
    | (tp ~ BVType 16) => GS
@@ -144,7 +148,6 @@ data X86PrimLoc tp
      -- ^ One of the x87 control registers
 
 instance HasRepr X86PrimLoc TypeRepr where
-  typeRepr ControlLoc{} = knownRepr
   typeRepr DebugLoc{}   = knownRepr
   typeRepr FS = knownRepr
   typeRepr GS = knownRepr
@@ -153,7 +156,6 @@ instance HasRepr X86PrimLoc TypeRepr where
       LeqProof -> BVTypeRepr (typeRepr r)
 
 instance Pretty (X86PrimLoc tp) where
-  pretty (ControlLoc r) = text (show r)
   pretty (DebugLoc r) = text (show r)
   pretty FS = text "fs"
   pretty GS = text "gs"

--- a/x86/src/Data/Macaw/X86/Getters.hs
+++ b/x86/src/Data/Macaw/X86/Getters.hs
@@ -233,7 +233,7 @@ getSomeBVLocation :: F.Value -> X86Generator st ids (SomeBV (Location (Addr ids)
 getSomeBVLocation v =
   case v of
     F.ControlReg _ -> fail "ControlReg"
-    F.DebugReg dr    -> pure $ SomeBV $ DebugReg dr
+    F.DebugReg _   -> fail "DebugReg"
     F.MMXReg mmx     -> pure $ SomeBV $ x87reg_mmx $ X87_FPUReg mmx
     F.XMMReg r       -> do avx <- isAVX
                            pure $ SomeBV $ if avx then xmm_avx r

--- a/x86/src/Data/Macaw/X86/Getters.hs
+++ b/x86/src/Data/Macaw/X86/Getters.hs
@@ -232,7 +232,7 @@ floatBVMemRepr fi | LeqProof <- floatInfoBytesIsPos fi =
 getSomeBVLocation :: F.Value -> X86Generator st ids (SomeBV (Location (Addr ids)))
 getSomeBVLocation v =
   case v of
-    F.ControlReg cr  -> pure $ SomeBV $ ControlReg cr
+    F.ControlReg _ -> fail "ControlReg"
     F.DebugReg dr    -> pure $ SomeBV $ DebugReg dr
     F.MMXReg mmx     -> pure $ SomeBV $ x87reg_mmx $ X87_FPUReg mmx
     F.XMMReg r       -> do avx <- isAVX

--- a/x86/src/Data/Macaw/X86/InstructionDef.hs
+++ b/x86/src/Data/Macaw/X86/InstructionDef.hs
@@ -84,13 +84,13 @@ defNullaryPrefix mnem f = defVariadic mnem (\pfx _ -> f pfx)
 -- | Define an instruction that expects a single argument
 defUnary :: String
             -- ^ Instruction mnemonic
-         -> (forall st ids . F.LockPrefix -> F.Value -> X86Generator st ids ())
+         -> (forall st ids . F.InstructionInstance -> F.Value -> X86Generator st ids ())
              -- ^ Sementic definition
          -> InstructionDef
-defUnary mnem f = defVariadic mnem $ \pfx vs ->
-  case vs of
-    [v]   -> f pfx v
-    _     -> fail $ "defUnary: " ++ mnem ++ " expecting 1 arguments, got " ++ show (length vs)
+defUnary mnem f = defInstruction mnem $ \ii ->
+  case F.iiArgs ii of
+    [v]   -> f ii (fst v)
+    vs     -> fail $ "defUnary: " ++ mnem ++ " expecting 1 arguments, got " ++ show (length vs)
 
 -- | Define an instruction that expects two arguments.
 defBinary :: String

--- a/x86/src/Data/Macaw/X86/Monad.hs
+++ b/x86/src/Data/Macaw/X86/Monad.hs
@@ -502,9 +502,6 @@ data Location addr (tp :: Type) where
   Register :: !(RegisterView m b n)
            -> Location addr (BVType n)
 
-  ControlReg :: !F.ControlReg
-             -> Location addr (BVType 64)
-
   DebugReg :: !F.DebugReg
            -> Location addr (BVType 64)
 
@@ -563,9 +560,6 @@ setLoc loc v =
    MemoryAddr w tp -> do
      addr <- eval w
      addStmt $ WriteMem addr tp v
-
-   ControlReg r -> do
-     addWriteLoc (ControlLoc r) v
    DebugReg r  ->
      addWriteLoc (DebugLoc r) v
 
@@ -620,7 +614,6 @@ ppLocation ppAddr loc = case loc of
   MemoryAddr addr _tr -> ppAddr addr
   Register rv -> ppReg rv
   FullRegister r -> text $ "%" ++ show r
-  ControlReg r -> text (show r)
   DebugReg r -> text (show r)
   SegmentReg r -> text (show r)
   X87ControlReg r -> text ("x87_" ++ show r)
@@ -687,7 +680,6 @@ instance HasRepr (Location addr) TypeRepr where
   typeRepr (MemoryAddr _ tp) = typeRepr tp
   typeRepr (FullRegister r)  = typeRepr r
   typeRepr (Register rv@RegisterView{}) = BVTypeRepr $ _registerViewSize rv
-  typeRepr (ControlReg _)    = knownRepr
   typeRepr (DebugReg _)    = knownRepr
   typeRepr (SegmentReg _)    = knownRepr
   typeRepr (X87ControlReg r) =
@@ -1563,8 +1555,6 @@ get l0 =
     MemoryAddr w tp -> do
       addr <- eval w
       evalAssignRhs (ReadMem addr tp)
-    ControlReg _ ->
-      fail $ "Do not support reading control registers."
     DebugReg _ ->
       fail $ "Do not support reading debug registers."
     SegmentReg s

--- a/x86/src/Data/Macaw/X86/Monad.hs
+++ b/x86/src/Data/Macaw/X86/Monad.hs
@@ -502,9 +502,6 @@ data Location addr (tp :: Type) where
   Register :: !(RegisterView m b n)
            -> Location addr (BVType n)
 
-  DebugReg :: !F.DebugReg
-           -> Location addr (BVType 64)
-
   SegmentReg :: !F.Segment
              -> Location addr (BVType 16)
 
@@ -560,9 +557,6 @@ setLoc loc v =
    MemoryAddr w tp -> do
      addr <- eval w
      addStmt $ WriteMem addr tp v
-   DebugReg r  ->
-     addWriteLoc (DebugLoc r) v
-
    SegmentReg s
      | s == F.FS -> addWriteLoc FS v
      | s == F.GS -> addWriteLoc GS v
@@ -614,7 +608,6 @@ ppLocation ppAddr loc = case loc of
   MemoryAddr addr _tr -> ppAddr addr
   Register rv -> ppReg rv
   FullRegister r -> text $ "%" ++ show r
-  DebugReg r -> text (show r)
   SegmentReg r -> text (show r)
   X87ControlReg r -> text ("x87_" ++ show r)
   X87StackRegister i -> text $ "x87_stack@" ++ show i
@@ -680,7 +673,6 @@ instance HasRepr (Location addr) TypeRepr where
   typeRepr (MemoryAddr _ tp) = typeRepr tp
   typeRepr (FullRegister r)  = typeRepr r
   typeRepr (Register rv@RegisterView{}) = BVTypeRepr $ _registerViewSize rv
-  typeRepr (DebugReg _)    = knownRepr
   typeRepr (SegmentReg _)    = knownRepr
   typeRepr (X87ControlReg r) =
     case x87ControlRegWidthIsPos r of
@@ -1555,8 +1547,6 @@ get l0 =
     MemoryAddr w tp -> do
       addr <- eval w
       evalAssignRhs (ReadMem addr tp)
-    DebugReg _ ->
-      fail $ "Do not support reading debug registers."
     SegmentReg s
       | s == F.FS -> readLoc FS
       | s == F.GS -> readLoc GS

--- a/x86/src/Data/Macaw/X86/Semantics.hs
+++ b/x86/src/Data/Macaw/X86/Semantics.hs
@@ -89,6 +89,29 @@ castFromXMMSingleVec :: Expr ids (VecType 4 (FloatType SingleFloat)) -> Expr ids
 castFromXMMSingleVec = bitcast (PackBits n4 n32) . bitcast (VecEqCongruence n4 fromSingle)
 
 ------------------------------------------------------------------------
+-- Getter
+
+data HasRepSize f w = HasRepSize { _ppvWidth :: !(RepValSize w)
+                                 , _ppvValue :: !(f (BVType w))
+                                 }
+
+-- | Gets the location to store the value poped from.
+-- These functions only support general purpose registers/addresses and segments.
+getAddrOrReg :: F.Value -> X86Generator st ids (Some (HasRepSize (Location (Addr ids))))
+getAddrOrReg v =
+  case v of
+    F.Mem8  ar -> Some . HasRepSize  ByteRepVal <$> getBV8Addr  ar
+    F.Mem16 ar -> Some . HasRepSize  WordRepVal <$> getBV16Addr ar
+    F.Mem32 ar -> Some . HasRepSize DWordRepVal <$> getBV32Addr ar
+    F.Mem64 ar -> Some . HasRepSize QWordRepVal <$> getBV64Addr ar
+
+    F.ByteReg  r -> pure $ Some $ HasRepSize  ByteRepVal $ reg8Loc  r
+    F.WordReg  r -> pure $ Some $ HasRepSize  WordRepVal $ reg16Loc r
+    F.DWordReg r -> pure $ Some $ HasRepSize DWordRepVal $ reg32Loc r
+    F.QWordReg r -> pure $ Some $ HasRepSize QWordRepVal $ reg64Loc r
+    _  -> fail $ "Argument " ++ show v ++ " not supported."
+
+------------------------------------------------------------------------
 -- Preliminaries
 
 -- The representation for a address
@@ -148,7 +171,7 @@ set_bitwise_flags res = do
 push :: MemRepr tp -> Expr ids tp -> X86Generator st ids ()
 push repr v = do
   old_sp <- get rsp
-  let delta   = bvLit n64 $ memReprBytes repr -- delta in bytes
+  let delta   = bvLit n64 (fromIntegral (memReprBytes repr)) -- delta in bytes
       new_sp  = old_sp .- delta
   MemoryAddr new_sp repr .= v
   rsp     .= new_sp
@@ -160,7 +183,7 @@ pop repr = do
   -- Get value at stack pointer.
   v   <- get (MemoryAddr old_sp repr)
   -- Increment stack pointer
-  rsp .= old_sp .+ bvLit n64 (memReprBytes repr)
+  rsp .= old_sp .+ bvLit n64 (fromIntegral (memReprBytes repr))
   -- Return value
   return v
 
@@ -322,15 +345,45 @@ def_cdqe = defNullary "cdqe" $ do
 def_pop :: InstructionDef
 def_pop =
   defUnary "pop" $ \_ fval -> do
-    Some (HasRepSize rep l) <- getAddrRegOrSegment fval
+    Some (HasRepSize rep l) <-
+      case fval of
+        F.SegmentValue _ ->
+          fail "pop does not support segment selector."
+        F.WordReg  r -> pure $ Some $ HasRepSize  WordRepVal $ reg16Loc r
+        F.DWordReg r -> pure $ Some $ HasRepSize DWordRepVal $ reg32Loc r
+        F.QWordReg r -> pure $ Some $ HasRepSize QWordRepVal $ reg64Loc r
+        F.Mem16 ar -> Some . HasRepSize  WordRepVal <$> getBV16Addr ar
+        F.Mem32 ar -> Some . HasRepSize DWordRepVal <$> getBV32Addr ar
+        F.Mem64 ar -> Some . HasRepSize QWordRepVal <$> getBV64Addr ar
+        _ ->
+          fail "pop given unexpected value."
     val <- pop (repValSizeMemRepr rep)
     l .= val
 
 def_push :: InstructionDef
 def_push =
-  defUnary "push" $ \_ val -> do
-    Some (HasRepSize rep v) <- getAddrRegSegmentOrImm val
-    push (repValSizeMemRepr rep) v
+  defUnary "push" $ \_ii val -> do
+    Some (HasRepSize rep v) <-
+      case val of
+        F.SegmentValue _ ->
+          fail "push does not support segment selector."
+        F.WordReg  r -> Some . HasRepSize  WordRepVal <$> get (reg16Loc r)
+        F.DWordReg r -> Some . HasRepSize DWordRepVal <$> get (reg32Loc r)
+        F.QWordReg r -> Some . HasRepSize QWordRepVal <$> get (reg64Loc r)
+        F.Mem16 ar -> Some . HasRepSize  WordRepVal <$> (get =<< getBV16Addr ar)
+        F.Mem32 ar -> Some . HasRepSize DWordRepVal <$> (get =<< getBV32Addr ar)
+        F.Mem64 ar -> Some . HasRepSize QWordRepVal <$> (get =<< getBV64Addr ar)
+        F.ByteImm  w -> pure $ Some $ HasRepSize ByteRepVal  $ bvLit n8  (toInteger w)
+        F.WordImm  w -> pure $ Some $ HasRepSize WordRepVal  $ bvLit n16 (toInteger w)
+        F.DWordImm i -> pure $ Some $ HasRepSize DWordRepVal $ getImm32 i
+        F.QWordImm w -> pure $ Some $ HasRepSize QWordRepVal $ bvLit n64 (toInteger w)
+        _ -> fail $ "Unexpected argument to push"
+    let repr = repValSizeMemRepr rep
+    old_sp <- get rsp
+    let delta   = bvLit n64 $ fromIntegral (memReprBytes repr) -- delta in bytes
+        new_sp  = old_sp .- delta
+    MemoryAddr new_sp repr .= v
+    rsp     .= new_sp
 
 -- | Sign extend ax -> dx:ax, eax -> edx:eax, rax -> rdx:rax, resp.
 def_cwd :: InstructionDef
@@ -430,32 +483,40 @@ def_mov =
         v <- get $ reg64Loc src
         l .= v
 
-      (F.Mem16 a, F.SegmentValue s) -> do
-        v <- get (SegmentReg s)
-        l <- getBV16Addr  a
-        l .= v
-      (F.WordReg r, F.SegmentValue s) -> do
-        v <- get (SegmentReg s)
-        reg16Loc r .= v
-      (F.DWordReg r, F.SegmentValue s) -> do
-        v <- get (SegmentReg s)
-        reg_low16 (R.X86_GP (F.reg32_reg r)) .= v
-      (F.QWordReg r, F.SegmentValue s) -> do
-        v <- get (SegmentReg s)
-        fullRegister (R.X86_GP r) .= uext' n64 v
+      -- Read segment selector
+      (dest, F.SegmentValue s) -> do
+        v <- evalArchFn (GetSegmentSelector s)
+        case dest of
+          F.Mem16 a -> do
+            l <- getBV16Addr a
+            l .= v
+          F.WordReg r -> do
+            reg16Loc r .= v
+          F.DWordReg r -> do
+            reg_low16 (R.X86_GP (F.reg32_reg r)) .= v
+          F.QWordReg r -> do
+            fullRegister (R.X86_GP r) .= uext' n64 v
+          _ -> do
+            fail $ "Unexpected argument to mov read segment register " ++ show dest
 
-      (F.SegmentValue s, F.Mem16 a) -> do
-        v <- get =<< getBV16Addr a
-        SegmentReg s .= v
-      (F.SegmentValue s, F.WordReg r) -> do
-        v <- get (fullRegister (R.X86_GP (F.reg16_reg r)))
-        SegmentReg s .= bvTrunc' n16 v
-      (F.SegmentValue s, F.DWordReg r) -> do
-        v <- get (fullRegister (R.X86_GP (F.reg32_reg r)))
-        SegmentReg s .= bvTrunc' n16 v
-      (F.SegmentValue s, F.QWordReg r) -> do
-        v <- get (fullRegister (R.X86_GP r))
-        SegmentReg s .= bvTrunc' n16 v
+      -- Write to segment selector
+      (F.SegmentValue s, src) -> do
+        v16 <-
+          case src of
+            F.Mem16 a -> do
+              eval =<< get =<< getBV16Addr a
+            F.WordReg r -> do
+              v <- get (fullRegister (R.X86_GP (F.reg16_reg r)))
+              eval (bvTrunc' n16 v)
+            F.DWordReg r -> do
+              v <- get (fullRegister (R.X86_GP (F.reg32_reg r)))
+              eval (bvTrunc' n16 v)
+            F.QWordReg r -> do
+              v <- get (fullRegister (R.X86_GP r))
+              eval (bvTrunc' n16 v)
+            _ -> do
+              error $ "Unexpected source to mov set segment register " ++ show src
+        addArchStmt $ SetSegmentSelector s v16
 
       (_, F.ControlReg _) -> do
         error "Do not support moving from/to control registers."
@@ -943,7 +1004,7 @@ def_sh :: String
           -- Takes current and new value of location.
        -> InstructionDef
 def_sh mnem val_setter cf_setter of_setter = defBinary mnem $ \_ii loc val -> do
-  Some (HasRepSize lw l) <- getAddrRegOrSegment loc
+  Some (HasRepSize lw l) <- getAddrOrReg loc
   repValSizeAtLeastByte lw $
     exec_sh lw l val val_setter cf_setter of_setter
 
@@ -989,7 +1050,7 @@ def_shXd mnemonic val_setter cf_setter of_setter =
   defTernary mnemonic $ \_ loc srcReg amt -> do
     -- srcVal <- get srcReg
     -- SomeBV srcVal <- getSomeBVValue srcReg
-    Some (HasRepSize lw l) <- getAddrRegOrSegment loc
+    Some (HasRepSize lw l) <- getAddrOrReg loc
     repValSizeAtLeastByte lw $ do
       srcVal <- getBVValue srcReg (typeWidth l)
       exec_sh lw l amt (val_setter srcVal) cf_setter of_setter
@@ -1303,7 +1364,7 @@ def_movs = defBinary "movs" $ \ii loc _ -> do
     F.Mem32{} -> pure (SomeRepValSize DWordRepVal)
     F.Mem64{} -> pure (SomeRepValSize QWordRepVal)
     _ -> error "Bad argument to movs"
-  let bytesPerOp = bvLit n64 (repValSizeByteCount w)
+  let bytesPerOp = bvLit n64 (fromIntegral (repValSizeByteCount w))
   dest <- get rdi
   src  <- get rsi
   df   <- get df_loc
@@ -1350,7 +1411,8 @@ exec_cmps repz_pfx rval = repValHasSupportedWidth rval $ do
   df <- get df_loc
   v_rsi <- get rsi
   v_rdi <- get rdi
-  let bytesPerOp = memReprBytes repr
+  let bytesPerOp :: Integer
+      bytesPerOp = toInteger (memReprBytes repr)
   let bytesPerOp' = bvLit n64 bytesPerOp
   if repz_pfx then do
     count <- get rcx
@@ -1434,8 +1496,10 @@ exec_scas False False rep = repValHasSupportedWidth rep $ do
   v_rax <- get (xaxValLoc rep)
   let memRepr = repValSizeMemRepr rep
   exec_cmp (MemoryAddr v_rdi memRepr) v_rax  -- FIXME: right way around?
-  let bytesPerOp = mux df (bvLit n64 (negate (memReprBytes memRepr)))
-                          (bvLit n64 (memReprBytes memRepr))
+  let memSize :: Integer
+      memSize = fromIntegral (memReprBytes memRepr)
+  let bytesPerOp = mux df (bvLit n64 (negate memSize))
+                          (bvLit n64 memSize)
   rdi   .= v_rdi .+ bytesPerOp
 -- repz or repnz prefix set
 exec_scas _repz_pfx False _rep =
@@ -1460,7 +1524,7 @@ exec_scas _repz_pfx True sz = repValHasSupportedWidth sz $ do
   v_rcx <- eval =<< get rcx
   count' <- evalArchFn (RepnzScas sz v_rax v_rdi v_rcx)
   -- Get number of bytes each comparison will use
-  let bytePerOpLit = bvKLit (memReprBytes (repValSizeMemRepr sz))
+  let bytePerOpLit = bvKLit (fromIntegral (memReprBytes (repValSizeMemRepr sz)))
 
   -- Count the number of bytes seen.
   let nBytesSeen    = (ValueExpr v_rcx .- count') .* bytePerOpLit
@@ -1518,8 +1582,8 @@ exec_lods False rep = do
   -- The direction flag indicates post decrement or post increment.
   df   <- get df_loc
   src  <- get rsi
-  let szv     = bvLit n64 (memReprBytes mrepr)
-      neg_szv = bvLit n64 (negate (memReprBytes mrepr))
+  let szv     = bvLit n64 (fromIntegral (memReprBytes mrepr))
+      neg_szv = bvLit n64 (negate (fromIntegral (memReprBytes mrepr)))
   v <- get (MemoryAddr src mrepr)
   (xaxValLoc rep) .= v
   rsi .= src .+ mux df neg_szv szv
@@ -1577,12 +1641,12 @@ def_stos = defBinary "stos" $ \ii loc loc' -> do
       let mrepr = repValSizeMemRepr rep
       count <- get rcx
       addArchStmt =<< traverseF eval (RepStos rep dest v count df)
-      rdi .= dest .+ bvKLit (memReprBytes mrepr) .* mux df (bvNeg count) count
+      rdi .= dest .+ bvKLit (fromIntegral (memReprBytes mrepr)) .* mux df (bvNeg count) count
       rcx .= bvKLit 0
     F.NoLockPrefix -> do
         let mrepr = repValSizeMemRepr rep
-        let neg_szv = bvLit n64 (negate (memReprBytes mrepr))
-        let szv     = bvLit n64 (memReprBytes mrepr)
+        let neg_szv = bvLit n64 (fromIntegral (negate (memReprBytes mrepr)))
+        let szv     = bvLit n64 (fromIntegral (memReprBytes mrepr))
         MemoryAddr dest mrepr .= v
         rdi .= dest .+ mux df neg_szv szv
     lockPrefix -> fail $ "stos unexpected lock/rep prefix: " ++ show lockPrefix
@@ -1838,12 +1902,12 @@ def_fnstcw :: InstructionDef
 def_fnstcw = defUnary "fnstcw" $ \_ loc -> do
   case loc of
     F.Mem16 f_addr -> do
-      addr <- getBVAddress f_addr
+      addr <- eval =<< getBVAddress f_addr
       set_undefined c0_loc
       set_undefined c1_loc
       set_undefined c2_loc
       set_undefined c3_loc
-      fnstcw addr
+      addArchStmt $ StoreX87Control addr
     _ -> fail $ "fnstcw given bad argument " ++ show loc
 
 -- FLDCW Load FPU control word

--- a/x86/src/Data/Macaw/X86/X87ControlReg.hs
+++ b/x86/src/Data/Macaw/X86/X87ControlReg.hs
@@ -26,7 +26,10 @@ import           Data.Macaw.Types
 import           Data.Parameterized.Classes
 import           Data.Parameterized.NatRepr
 
--- | One of the X87 control registrs
+-- | This is one of the fields in the x87 FPU control word.
+--
+-- The fields indicate the index of the least-significant bit that is part of
+-- the field, and the number of bits in the field.
 data X87_ControlReg w = (1 <= w) => X87_ControlReg !Int !(NatRepr w)
 
 instance TestEquality X87_ControlReg where

--- a/x86/tests/x64/Makefile
+++ b/x86/tests/x64/Makefile
@@ -20,6 +20,9 @@ test-tail-call.exe: test-tail-call.c
 %.o: %.c
 	clang -c --target=x86_64-pc-linux-elf -o $@ $<
 
+%.o: %.s
+	clang -c --target=x86_64-pc-linux-elf -o $@ $<
+
 .PRECIOUS: %.s
 
 clean:

--- a/x86/x86_tests/Makefile
+++ b/x86/x86_tests/Makefile
@@ -3,13 +3,22 @@ tests = btx_test.exe ucomis_test.exe pop_test.exe ret_test.exe
 run : $(tests)
 	set -e; for v in $(tests); do echo "Running $$v"; ./$$v; done
 
-%_test.exe : %_test.c %_run.s utils.h
-	clang -o $@ $*_test.c $*_run.s
+%.o : %.s
+	clang -c -o $@ $<
 
-test_%.exe : test_%.c %.s utils.h
-	clang -o $@ test_$*.c $*.s
+%.o : %.c
+	clang -c -Wall -Werror -std=c11 -o $@ $<
+
+expect_segfault.o : utils.h expect_segfault.h
+
+%_test.exe : %_test.o %_run.o utils.h
+	clang -o $@ $(filter %.o,$^)
+# ($^:%.o=%.o)
+
+fsgs_test.exe : expect_segfault.o
 
 clean :
 	rm -rf $(tests)
 
 .PHONY : run clean
+.PRECIOUS : %.o

--- a/x86/x86_tests/expect_segfault.c
+++ b/x86/x86_tests/expect_segfault.c
@@ -1,0 +1,75 @@
+#include "expect_segfault.h"
+#include "utils.h"
+
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+
+
+
+
+
+// Global to indicate segfault occured.
+
+volatile sig_atomic_t segfault = 0;
+
+// Set segfault and exit pthread.
+static
+void segfault_sigaction(int signal, siginfo_t *si, void *arg)
+{
+    segfault = 1;
+    pthread_exit(0);
+}
+
+// A pair with test function and argument.
+struct test_pair {
+    test_fn fn;
+    void* arg;
+};
+
+// pthread function for running user test case.
+static
+void* thread_fn(void* arg) {
+
+    struct test_pair* s = (struct test_pair *) arg;
+
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(struct sigaction));
+    sigemptyset(&sa.sa_mask);
+    sa.sa_sigaction = segfault_sigaction;
+    sa.sa_flags   = SA_SIGINFO;
+
+    struct sigaction oldsa;
+    sigaction(SIGSEGV, &sa, &oldsa);
+
+    s->fn(s->arg);
+
+    sigaction(SIGSEGV, &oldsa, 0);
+
+    return 0;
+}
+
+// Run a test case with given argument. that is expected to segfault.
+void expect_segfault(test_fn test, void* arg, const char* testname) {
+    pthread_t waiting_thread;
+    segfault = 0;
+
+    struct test_pair s;
+    s.fn = test;
+    s.arg = arg;
+
+    int res = pthread_create(&waiting_thread, 0, &thread_fn, &s);
+    if (res) {
+        fprintf(stderr, "Thread creation failed\n");
+    }
+
+
+    void* status;
+    res = pthread_join(waiting_thread, &status);
+    if (res) {
+        fprintf(stderr, "Waiting for termination failed\n");
+    }
+
+    my_assert(segfault, testname);
+}

--- a/x86/x86_tests/expect_segfault.h
+++ b/x86/x86_tests/expect_segfault.h
@@ -1,0 +1,7 @@
+// Provides operation for testing a C function triggers a segfault.
+
+// Function for user test case.
+typedef void (*test_fn)(void*);
+
+
+void expect_segfault(test_fn test, void* arg, const char* testname);

--- a/x86/x86_tests/fsgs_run.s
+++ b/x86/x86_tests/fsgs_run.s
@@ -1,0 +1,80 @@
+// Thi sfile defines functions for getting and setting the fs and gs register
+.section __TEXT,__text
+
+
+.global _pushw_fs
+_pushw_fs:
+        mov %rsp, %rax
+        pushw %fs
+        sub %rsp, %rax
+        popw (%rdi)
+        ret
+
+.global _pushq_fs
+_pushq_fs:
+        mov %rsp, %rax
+        pushq %fs
+        sub %rsp, %rax
+        popq (%rdi)
+        ret
+
+.global _getw_fs
+_getw_fs:
+        mov $0x123456789abcdef, %rax
+        movw %fs, %ax
+        ret
+
+.global _getq_fs
+_getq_fs:
+        movq %fs, %rax
+        ret
+
+.global _setw_fs
+_setw_fs:
+        movw %di, %fs
+        ret
+
+.global _setq_fs
+_setq_fs:
+        movq %rdi, %fs
+        ret
+
+// Accessing gs
+
+.global _pushw_gs
+_pushw_gs:
+        mov %rsp, %rax
+        pushw %gs
+        sub %rsp, %rax
+        popw (%rdi)
+        ret
+
+.global _pushq_gs
+_pushq_gs:
+        mov %rsp, %rax
+        pushq %gs
+        sub %rsp, %rax
+        popq (%rdi)
+        ret
+
+.global _getw_gs
+_getw_gs:
+        // Move constant into %rax so value is more clear.
+        mov $0x123456789abcdef, %rax
+        movw %gs, %ax
+        ret
+
+.global _getq_gs
+_getq_gs:
+        movq %gs, %rax
+        ret
+
+.global _setw_gs
+_setw_gs:
+        movw %di, %gs
+        ret
+
+.global _setq_gs
+_setq_gs:
+        movq %rdi, %gs
+        ret

--- a/x86/x86_tests/fsgs_test.c
+++ b/x86/x86_tests/fsgs_test.c
@@ -1,0 +1,46 @@
+// This file tests the push and mov instructions with segment registers.
+#include "utils.h"
+#include "expect_segfault.h"
+
+uint64_t pushw_fs(uint16_t* p);
+uint64_t pushq_fs(uint64_t* p);
+uint64_t getw_fs();
+uint64_t getq_fs();
+
+void setw_fs(uint64_t x);
+void setq_fs(uint64_t x);
+
+// Setw that is expected to segfault.
+void setw_illegal(void* arg) {
+    setw_fs(5);
+}
+
+// Setq that is expected to segfault.
+void setq_illegal(void* arg) {
+    setq_fs(5);
+}
+
+int main(int argc, char** argv) {
+    uint16_t w;
+    uint64_t q;
+    uint64_t sz;
+
+    sz = pushw_fs(&w);
+    my_assert(sz == 2, "pushw_fs size 2\n");
+    my_assert(w  == 0, "pushw_fs result 0\n");
+
+    sz = pushq_fs(&q);
+    my_assert(sz == 8, "pushq_fs size 8\n");
+    my_assert(q  == 0, "pushq_fs result 0\n");
+
+    // Check getw and getq
+    my_assert(getw_fs() == 0x123456789ab0000, "getw_fs is expected.");
+    my_assert(getq_fs() == 0, "getq_fs is expected.");
+
+    for (uint64_t i=0; i != 4; ++i) {
+        setw_fs(0x10000 + i);
+        my_assert(getq_fs() == i, "setwget expected");
+    }
+    expect_segfault(&setw_illegal, 0, "setw_illegal expected segfault.\n");
+    expect_segfault(&setq_illegal, 0, "setq_illegal expected segfault.\n");
+}

--- a/x86/x86_tests/utils.h
+++ b/x86/x86_tests/utils.h
@@ -1,3 +1,8 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 // Functions needed by multiple test cases
 
 // Assert condition is true, and exit if not.
@@ -15,17 +20,17 @@ void my_assert(bool b, const char* fmt, ...) {
 ////////////////////////////////////////////////////////////////////////
 // Flags register access
 
-static
+static inline
 bool get_cf(uint64_t flags) {
     return (flags & 0x01) != 0;
 }
 
-static
+static inline
 bool get_pf(uint64_t flags) {
     return (flags & 0x04) != 0;
 }
 
-static
+static inline
 bool get_zf(uint64_t flags) {
     return (flags & 0x40) != 0;
 }
@@ -38,7 +43,7 @@ typedef union {
     uint32_t i;
 } float_union;
 
-static
+static inline
 float mk_float(uint32_t sign, uint8_t exp, uint32_t fraction) {
     float_union s;
     s.i = sign << 31 | exp << 23 | fraction;
@@ -46,7 +51,7 @@ float mk_float(uint32_t sign, uint8_t exp, uint32_t fraction) {
 }
 
 // Return the exponent value of a float
-static
+static inline
 uint8_t float_exp(float f) {
     float_union s;
     s.f = f;
@@ -54,33 +59,34 @@ uint8_t float_exp(float f) {
 }
 
 // Return the mantissa value of a float
-static
+static inline
 uint8_t float_mantissa(float f) {
     float_union s;
     s.f = f;
     return s.i & 0x7fffff;
 }
 
-static
+static inline
 float mk_snan(uint32_t sign, uint32_t fraction) {
     uint32_t mask = (1 << 22) - 1;
     return mk_float(sign, 0xff, fraction & mask);
 }
 
-static
+static inline
 float mk_qnan(uint32_t sign, uint32_t fraction) {
     uint32_t mask = (1 << 22) - 1;
     return mk_float(sign, 0xff, (1 << 22) | (fraction & mask));
 }
 
 // Return true if the floating point is a nan.
-static
+static inline
 bool float_is_nan(float f) {
     return (float_exp(f) == 0xff)
 	&& (float_mantissa(f) != 0);
 }
 
 // Return the bits in the float
+static inline
 uint32_t float_bits(float x) {
     float_union s;
     s.f = x;

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -223,7 +223,6 @@ pureSem sym fn = do
       do x <- getBitVal (symIface sym) x0
          evalE sym $ app $ Not $ foldr1 xor [ bvTestBit x i | i <- [ 0 .. 7 ] ]
       where xor a b = app (BoolXor a b)
-    M.ReadLoc {} -> error "ReadLoc"
     M.ReadFSBase    -> error " ReadFSBase"
     M.ReadGSBase    -> error "ReadGSBase"
     M.GetSegmentSelector _ -> error "GetSegmentSelector"

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -107,7 +107,8 @@ withConcreteCountAndDir
   -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
 withConcreteCountAndDir state val_size wrapped_count _wrapped_dir func = do
   let sym = state^.stateSymInterface
-  let val_byte_size = M.repValSizeByteCount val_size
+  let val_byte_size :: Integer
+      val_byte_size = fromIntegral $ M.repValSizeByteCount val_size
   bv_count <- toValBV sym wrapped_count
   case asConcrete bv_count of
     Just (ConcreteBV _ count) -> do


### PR DESCRIPTION
This patch does a few too many things, but generally aims to remove some functionality from the x86 backend that was not actually needed and not clearly documented.

It also renames a few core Macaw declarations for perceived greater clarity.