### PR TITLE
Update macaw-semmc to work with crucible changes

### DIFF
--- a/macaw-semmc/src/Data/Macaw/SemMC/TH.hs
+++ b/macaw-semmc/src/Data/Macaw/SemMC/TH.hs
@@ -816,7 +816,7 @@ defaultAppEvaluator elt interps = case elt of
       CT.BaseNatRepr -> liftQ [| error "Macaw semantics for nat ITE unsupported" |]
       CT.BaseIntegerRepr -> liftQ [| error "Macaw semantics for integer ITE unsupported" |]
       CT.BaseRealRepr -> liftQ [| error "Macaw semantics for real ITE unsupported" |]
-      CT.BaseStringRepr -> liftQ [| error "Macaw semantics for string ITE unsupported" |]
+      CT.BaseStringRepr {} -> liftQ [| error "Macaw semantics for string ITE unsupported" |]
       CT.BaseComplexRepr -> liftQ [| error "Macaw semantics for complex ITE unsupported" |]
       CT.BaseStructRepr {} -> liftQ [| error "Macaw semantics for struct ITE unsupported" |]
       CT.BaseArrayRepr {} -> liftQ [| error "Macaw semantics for array ITE unsupported" |]


### PR DESCRIPTION
The improved string support in Crucible adds a parameter to string reprs; this
change accommodates that.  Earlier changes added the necessary support in the
rest of macaw.