### PR TITLE
Update the crucible submodule

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -365,8 +365,9 @@ binOpLabel lab x y =
 
 check :: IsSymInterface sym => sym -> Pred sym -> String -> String -> IO ()
 check sym valid name msg = assert sym valid
-                    $ AssertFailureSimError
-                    $ "[" ++ name ++ "] " ++ msg
+                    $ AssertFailureSimError errMsg errMsg
+  where
+    errMsg = "[" ++ name ++ "] " ++ msg
 
 -- | Define an operation by cases.
 cases ::
@@ -772,8 +773,8 @@ doCondReadMem sym mem ptrWidth memRep cond ptr def = hasPtrClass ptrWidth $
      val <- Mem.assertSafe sym =<< Mem.loadRaw sym mem ptr ty alignment
      let useDefault msg =
            do notC <- notPred sym cond
-              assert sym notC
-                (AssertFailureSimError ("[doCondReadMem] " ++ msg))
+              let errMsg = "[doCondReadMem] " ++ msg
+              assert sym notC (AssertFailureSimError errMsg errMsg)
               return def
      case memValToCrucible memRep val of
        Left err -> useDefault err

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -515,7 +515,8 @@ getDenominator dw sym macawDenom = do
   -- Check denominator is not 0
   do let bvZ = app (BVLit dw 0)
      denNotZero <- evalApp sym $ Not (app (BVEq dw den bvZ))
-     assert symi denNotZero (C.AssertFailureSimError "denominator not zero")
+     let errMsg = "denominator not zero"
+     assert symi denNotZero (C.AssertFailureSimError errMsg (errMsg ++ " in Data.Macaw.X86.Crucible.getDenominator"))
   pure den
 
 -- | Performs a simple unsigned division operation.
@@ -553,7 +554,8 @@ uDivRem sym repsz macawNum1 macawNum2 macawDenom =
     -- Check quotient did not overflow.
     do let qExt' = app (BVZext nw dw (ValBV dw qBV))
        qNoOverflow <- evalApp sym $ BVEq nw (ValBV nw qExt) qExt'
-       assert symi qNoOverflow (C.AssertFailureSimError "quotient no overflow")
+       let errMsg = "quotient no overflow"
+       assert symi qNoOverflow (C.AssertFailureSimError errMsg (errMsg ++ " in Data.Macaw.X86.Crucible.uDivRem"))
     -- Get quotient
     q <- llvmPointer_bv symi qBV
     -- Get remainder
@@ -591,7 +593,8 @@ sDivRem sym repsz macawNum1 macawNum2 macawDenom =
     -- Check quotient did not overflow.
     do let qExt' = app (BVSext nw dw (ValBV dw qBV))
        qNoOverflow <- evalApp sym $ BVEq nw (ValBV nw qExt) qExt'
-       assert symi qNoOverflow (C.AssertFailureSimError "quotient no overflow")
+       let errMsg = "quotient no overflow"
+       assert symi qNoOverflow (C.AssertFailureSimError errMsg (errMsg ++ " in Data.Macaw.X86.Crucible.sDivRem"))
     -- Get quotient
     q <- llvmPointer_bv symi qBV
     -- Get remainder


### PR DESCRIPTION
The only real code change required is that simulation failure messages have an
extra argument.  The goal with this update is to pull in some fixes to the
solver feature detection for yices in the latest crucible.