### PR TITLE
Fix warnings

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/Backend.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Backend.hs
@@ -43,7 +43,6 @@ module Data.Macaw.Symbolic.Backend (
   ) where
 
 import qualified Lang.Crucible.CFG.Core as C
-import qualified Lang.Crucible.LLVM.MemModel as MM
 import qualified Lang.Crucible.Simulator as C
 import qualified Data.Macaw.CFG.Core as M
 

--- a/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
@@ -352,6 +352,8 @@ instance ArchInfo M.X86_64 where
         sfns <- liftIO $ newSymFuns sym
         k $ x86_64MacawEvalFn sfns
     , withArchConstraints = \x -> x
+    , withArchEvalTrace = \_ _ ->
+        error "The trace memory model is not supported on x86 yet"
     , lookupReg = x86LookupReg
     , updateReg = x86UpdateReg
     }


### PR DESCRIPTION
Accidentally introduced some warnings in macaw-symbolic on the aarch32 merge