### PR TITLE
Clean up the PowerPC architecture specifications

### DIFF
--- a/macaw-ppc-symbolic/macaw-ppc-symbolic.cabal
+++ b/macaw-ppc-symbolic/macaw-ppc-symbolic.cabal
@@ -34,6 +34,7 @@ library
                        crucible-llvm,
                        macaw-ppc,
                        semmc,
+                       semmc-ppc,
                        what4
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/macaw-ppc/src/Data/Macaw/PPC.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC.hs
@@ -82,7 +82,7 @@ type PPC64 = AnyPPC V64
 -- | The type tag for 32-bit PowerPC
 type PPC32 = AnyPPC V32
 
-archDemandContext :: (ppc ~ PPC.AnyPPC var, PPCArchConstraints var) => proxy ppc -> MDS.DemandContext ppc
+archDemandContext :: (PPCArchConstraints var) => proxy var -> MDS.DemandContext (PPC.AnyPPC var)
 archDemandContext _ =
   MDS.DemandContext { MDS.demandConstraints = \a -> a
                     , MDS.archFnHasSideEffects = ppcPrimFnHasSideEffects
@@ -112,7 +112,7 @@ ppc64_linux_info binData =
                       , MI.extractBlockPrecond = PPC.Eval.ppcExtractBlockPrecond
                       }
   where
-    proxy = Proxy @PPC64.PPC
+    proxy = Proxy @PPC.V64
 
 ppc32_linux_info :: ( BLP.HasTOC PPC32.PPC binFmt
                     ) =>
@@ -139,5 +139,4 @@ ppc32_linux_info binData =
                       , MI.extractBlockPrecond = PPC.Eval.ppcExtractBlockPrecond
                       }
   where
-    proxy = Proxy @PPC32.PPC
-
+    proxy = Proxy @PPC.V32

--- a/macaw-ppc/src/Data/Macaw/PPC/Disassemble.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Disassemble.hs
@@ -40,7 +40,6 @@ import qualified SemMC.Architecture.PPC as SP
 import           Data.Macaw.SemMC.Generator
 import           Data.Macaw.SemMC.Simplify ( simplifyValue )
 import           Data.Macaw.PPC.Arch ( PPCArchConstraints )
-import           Data.Macaw.PPC.PPCReg
 
 -- | Read one instruction from the 'MM.Memory' at the given segmented offset.
 --
@@ -186,7 +185,7 @@ tryDisassembleBlock lookupSemantics nonceGen startAddr regState maxSize = do
 -- Return a list of disassembled blocks as well as the total number of bytes
 -- occupied by those blocks.
 disassembleFn :: (ppc ~ SP.AnyPPC var, PPCArchConstraints var)
-              => proxy ppc
+              => proxy var
               -> (Value ppc ids (BVType (ArchAddrWidth ppc)) -> D.Instruction -> Maybe (Generator ppc ids s ()))
               -- ^ A function to look up the semantics for an instruction.  The
               -- lookup is provided with the value of the IP in case IP-relative
@@ -266,13 +265,13 @@ liftST = DisM . lift
 -- that translation of the basic block resulted in an error (with the exception
 -- string stored as its argument).  This allows macaw to carry errors in the
 -- instruction stream, which is useful for debugging and diagnostics.
-failAt :: forall ppc ids s a
-        . (ArchReg ppc ~ PPCReg ppc, MM.MemWidth (ArchAddrWidth ppc))
-       => GenState ppc ids s
-       -> MM.MemWord (ArchAddrWidth ppc)
-       -> MM.MemSegmentOff (ArchAddrWidth ppc)
-       -> TranslationErrorReason (ArchAddrWidth ppc)
-       -> DisM ppc ids s a
+failAt :: forall v ids s a
+        . (MM.MemWidth (SP.AddrWidth v))
+       => GenState (SP.AnyPPC v) ids s
+       -> MM.MemWord (SP.AddrWidth v)
+       -> MM.MemSegmentOff (SP.AddrWidth v)
+       -> TranslationErrorReason (SP.AddrWidth v)
+       -> DisM (SP.AnyPPC v) ids s a
 failAt gs offset curIPAddr reason = do
   let exn = TranslationError { transErrorAddr = curIPAddr
                              , transErrorReason = reason

--- a/macaw-ppc/src/Data/Macaw/PPC/Operand.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Operand.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | Instance definitions to assist in extracting Macaw values from instruction operands
 --
@@ -21,73 +22,61 @@ import qualified Data.Parameterized.NatRepr as NR
 import qualified Data.Macaw.CFG.Core as MC
 import           Data.Macaw.Types
 import qualified Dismantle.PPC as D
+import           GHC.TypeLits ( type (<=) )
 
-import qualified SemMC.Architecture.PPC32 as PPC32
-import qualified SemMC.Architecture.PPC64 as PPC64
+import qualified SemMC.Architecture.PPC as PPC
 import           Data.Macaw.SemMC.Operands
 import qualified Data.Macaw.PPC.PPCReg as R
 
-instance ExtractValue PPC32.PPC D.GPR (BVType 32) where
+instance (w ~ PPC.AddrWidth v, 1 <= w) => ExtractValue (PPC.AnyPPC v) D.GPR (BVType w) where
   extractValue regs gpr = regs ^. MC.boundValue (R.PPC_GP gpr)
 
-instance ExtractValue PPC32.PPC (Maybe D.GPR) (BVType 32) where
+instance (PPC.KnownVariant v, w ~ PPC.AddrWidth v) => ExtractValue (PPC.AnyPPC v) (Maybe D.GPR) (BVType w) where
   extractValue regs mgpr =
     case mgpr of
       Just gpr -> extractValue regs gpr
-      Nothing -> MC.BVValue NR.knownNat 0
+      Nothing -> MC.BVValue (PPC.addrWidth (PPC.knownVariant @v)) 0
 
-instance ExtractValue PPC64.PPC D.GPR (BVType 64) where
-  extractValue regs gpr = regs ^. MC.boundValue (R.PPC_GP gpr)
-
-instance ExtractValue PPC64.PPC (Maybe D.GPR) (BVType 64) where
-  extractValue regs mgpr =
-    case mgpr of
-      Just gpr -> extractValue regs gpr
-      Nothing -> MC.BVValue NR.knownNat 0
-
-instance (MC.ArchReg ppc ~ R.PPCReg ppc) => ExtractValue ppc D.FR (BVType 128) where
+instance ExtractValue (PPC.AnyPPC v) D.FR (BVType 128) where
   extractValue regs (D.FR fr) = regs ^. MC.boundValue (R.PPC_FR (D.VSReg fr))
 
-instance (MC.ArchReg ppc ~ R.PPCReg ppc) => ExtractValue ppc D.VR (BVType 128) where
+instance ExtractValue (PPC.AnyPPC v) D.VR (BVType 128) where
   extractValue regs (D.VR vr) = regs ^. MC.boundValue (R.PPC_FR (D.VSReg (vr + 32)))
 
-instance (MC.ArchReg ppc ~ R.PPCReg ppc) => ExtractValue ppc D.VSReg (BVType 128) where
+instance ExtractValue (PPC.AnyPPC v) D.VSReg (BVType 128) where
   extractValue regs (D.VSReg vsr) = regs ^. MC.boundValue (R.PPC_FR (D.VSReg vsr))
 
-instance ExtractValue arch D.AbsBranchTarget (BVType 24) where
+instance ExtractValue (PPC.AnyPPC v) D.AbsBranchTarget (BVType 24) where
   extractValue _ (D.ABT w) = MC.BVValue NR.knownNat (toIntegerWord w)
 
-instance ExtractValue arch D.CondBranchTarget (BVType 14) where
+instance ExtractValue (PPC.AnyPPC v) D.CondBranchTarget (BVType 14) where
   extractValue _ (D.CBT i) = MC.BVValue NR.knownNat (toIntegerWord i)
 
-instance ExtractValue arch D.AbsCondBranchTarget (BVType 14) where
+instance ExtractValue (PPC.AnyPPC v) D.AbsCondBranchTarget (BVType 14) where
   extractValue _ (D.ACBT w) = MC.BVValue NR.knownNat (toIntegerWord w)
 
-instance ExtractValue arch D.BranchTarget (BVType 24) where
+instance ExtractValue (PPC.AnyPPC v) D.BranchTarget (BVType 24) where
   extractValue _ (D.BT i) = MC.BVValue NR.knownNat (toIntegerWord i)
 
-instance ExtractValue arch D.CRBitM (BVType 4) where
+instance ExtractValue (PPC.AnyPPC v) D.CRBitM (BVType 4) where
   extractValue _ (D.CRBitM b) = MC.BVValue NR.knownNat (toIntegerWord b)
 
-instance ExtractValue arch D.CRBitRC (BVType 5) where
+instance ExtractValue (PPC.AnyPPC v) D.CRBitRC (BVType 5) where
   extractValue _ (D.CRBitRC b) = MC.BVValue NR.knownNat (toIntegerWord b)
 
-instance ExtractValue arch D.CRRC (BVType 3) where
+instance ExtractValue (PPC.AnyPPC v) D.CRRC (BVType 3) where
   extractValue _ (D.CRRC b) = MC.BVValue NR.knownNat (toIntegerWord b)
 
-instance ToRegister D.GPR (R.PPCReg PPC32.PPC) (BVType 32) where
+instance (PPC.KnownVariant v, w ~ PPC.AddrWidth v) => ToRegister D.GPR (R.PPCReg v) (BVType w) where
   toRegister = R.PPC_GP
 
-instance ToRegister D.GPR (R.PPCReg PPC64.PPC) (BVType 64) where
-  toRegister = R.PPC_GP
-
-instance ToRegister D.FR (R.PPCReg arch) (BVType 128) where
+instance ToRegister D.FR (R.PPCReg v) (BVType 128) where
   toRegister (D.FR rnum) = R.PPC_FR (D.VSReg rnum)
 
-instance ToRegister D.VR (R.PPCReg arch) (BVType 128) where
+instance ToRegister D.VR (R.PPCReg v) (BVType 128) where
   toRegister (D.VR vrnum) = R.PPC_FR (D.VSReg (vrnum + 32))
 
-instance ToRegister D.VSReg (R.PPCReg arch) (BVType 128) where
+instance ToRegister D.VSReg (R.PPCReg v) (BVType 128) where
   toRegister = R.PPC_FR
 
 -- | Convert to a positive integer through a word type

--- a/macaw-ppc/src/Data/Macaw/PPC/PPCReg.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/PPCReg.hs
@@ -107,15 +107,6 @@ linuxCalleeSaveRegisters _ =
 type instance MC.RegAddrWidth (PPCReg v) = PPC.AddrWidth v
 type instance MC.ArchReg (PPC.AnyPPC v) = PPCReg v
 
--- {-# DEPRECATED
---       ArchWidth "Use 'SemMC.Architecture.AddrWidth' and 'SemMC.Architecture.addrWidth'."
--- #-}
--- class ArchWidth arch where
---   pointerNatRepr :: proxy arch -> NatRepr (MC.RegAddrWidth (PPCReg arch))
-
--- instance PPC.KnownVariant v => ArchWidth (PPC.AnyPPC v) where
---   pointerNatRepr _ = PPC.addrWidth (PPC.knownVariant @v)
-
 instance (PPC.KnownVariant v) => HasRepr (PPCReg v) TypeRepr where
   typeRepr r =
     case r of

--- a/macaw-ppc/src/Data/Macaw/PPC/Semantics/PPC32.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Semantics/PPC32.hs
@@ -13,7 +13,7 @@ import           Dismantle.PPC
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Macaw.Types as MT
-import           SemMC.Architecture.PPC32 ( PPC )
+import qualified SemMC.Architecture.PPC as SP
 import           SemMC.Architecture.PPC32.Opcodes ( allSemantics, allOpcodeInfo, allDefinedFunctions )
 
 import           Data.Macaw.SemMC.Generator ( Generator )
@@ -22,12 +22,12 @@ import           Data.Macaw.PPC.Arch ( ppcInstructionMatcher )
 import           Data.Macaw.PPC.PPCReg ( locToRegTH )
 import           Data.Macaw.PPC.Semantics.TH ( ppcAppEvaluator, ppcNonceAppEval )
 
-execInstruction :: MC.Value PPC ids (MT.BVType 32) -> Instruction -> Maybe (Generator PPC ids s ())
-execInstruction = $(genExecInstruction (Proxy @PPC) (locToRegTH (Proxy @PPC))
+execInstruction :: MC.Value (SP.AnyPPC SP.V32) ids (MT.BVType 32) -> Instruction -> Maybe (Generator (SP.AnyPPC SP.V32) ids s ())
+execInstruction = $(genExecInstruction (Proxy @(SP.AnyPPC SP.V32)) (locToRegTH (Proxy @SP.V32))
                     ppcNonceAppEval
                     ppcAppEvaluator
                     'ppcInstructionMatcher
                     allSemantics allOpcodeInfo allDefinedFunctions
-                    ([t| Dismantle.PPC.Operand |], [t| PPC |])
+                    ([t| Dismantle.PPC.Operand |], [t| (SP.AnyPPC SP.V32) |])
                     MM.BigEndian
                    )

--- a/macaw-ppc/src/Data/Macaw/PPC/Semantics/PPC64.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Semantics/PPC64.hs
@@ -13,7 +13,7 @@ import           Dismantle.PPC
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Macaw.Types as MT
-import           SemMC.Architecture.PPC64 ( PPC )
+import qualified SemMC.Architecture.PPC as SP
 import           SemMC.Architecture.PPC64.Opcodes ( allSemantics, allOpcodeInfo
                                                   , allDefinedFunctions )
 
@@ -23,6 +23,6 @@ import           Data.Macaw.PPC.Arch ( ppcInstructionMatcher )
 import           Data.Macaw.PPC.PPCReg ( locToRegTH )
 import           Data.Macaw.PPC.Semantics.TH ( ppcAppEvaluator, ppcNonceAppEval )
 
-execInstruction :: MC.Value PPC ids (MT.BVType 64) -> Instruction -> Maybe (Generator PPC ids s ())
-execInstruction = $(genExecInstruction (Proxy @PPC) (locToRegTH (Proxy @PPC)) ppcNonceAppEval ppcAppEvaluator 'ppcInstructionMatcher allSemantics allOpcodeInfo allDefinedFunctions
-                    ([t| Dismantle.PPC.Operand |], [t| PPC |]) MM.BigEndian)
+execInstruction :: MC.Value (SP.AnyPPC SP.V64) ids (MT.BVType 64) -> Instruction -> Maybe (Generator (SP.AnyPPC SP.V64) ids s ())
+execInstruction = $(genExecInstruction (Proxy @(SP.AnyPPC SP.V64)) (locToRegTH (Proxy @SP.V64)) ppcNonceAppEval ppcAppEvaluator 'ppcInstructionMatcher allSemantics allOpcodeInfo allDefinedFunctions
+                    ([t| Dismantle.PPC.Operand |], [t| (SP.AnyPPC SP.V64) |]) MM.BigEndian)


### PR DESCRIPTION
This commit reduces duplication by defining some instances in terms of the
parameterized AnyPPC architecture.  It also removes some code that was marked as
deprecated, now that we can use the infrastructure built up around AnyPPC.