### PR TITLE
Fixed buggy rewrite rules involving testBit/shifts

### DIFF
--- a/base/src/Data/Macaw/CFG/Rewriter.hs
+++ b/base/src/Data/Macaw/CFG/Rewriter.hs
@@ -507,13 +507,17 @@ rewriteApp app = do
     -- (x << j) testBit i ~> x testBit (i-j)
     -- plus a couple special cases for when the tested bit falls outside the shifted value
     BVTestBit (valueAsApp -> Just (BVShr w x (BVValue _ j))) (BVValue _ i)
-      | j + i <= maxUnsigned w -> do
+      | j + i < intValue w ->
       rewriteApp (BVTestBit x (BVValue w (j + i)))
+      | otherwise -> pure (boolLitValue False)
     BVTestBit (valueAsApp -> Just (BVSar w x (BVValue _ j))) (BVValue _ i)
-      | i < intValue w -> do
-      rewriteApp (BVTestBit x (BVValue w (min (j + i) (intValue w-1))))
+      | j + i < intValue w ->
+      rewriteApp (BVTestBit x (BVValue w (j + i)))
+      | i < intValue w -> pure (boolLitValue True)
+      | otherwise -> pure (boolLitValue False)
     BVTestBit (valueAsApp -> Just (BVShl w x (BVValue _ j))) (BVValue _ i)
-      | j <= i -> rewriteApp (BVTestBit x (BVValue w (i - j)))
+      | 0 <= i - j && i <= intValue w ->
+      rewriteApp (BVTestBit x (BVValue w (i - j)))
       | otherwise -> pure (boolLitValue False)
 
     BVComplement w (BVValue _ x) -> do

--- a/base/src/Data/Macaw/CFG/Rewriter.hs
+++ b/base/src/Data/Macaw/CFG/Rewriter.hs
@@ -513,10 +513,10 @@ rewriteApp app = do
     BVTestBit (valueAsApp -> Just (BVSar w x (BVValue _ j))) (BVValue _ i)
       | j + i < intValue w ->
       rewriteApp (BVTestBit x (BVValue w (j + i)))
-      | i < intValue w -> pure (boolLitValue True)
-      | otherwise -> pure (boolLitValue False)
+      | i < intValue w ->
+      rewriteApp (BVTestBit x (BVValue w (intValue w - 1)))
     BVTestBit (valueAsApp -> Just (BVShl w x (BVValue _ j))) (BVValue _ i)
-      | 0 <= i - j && i < intValue w ->
+      | j <= i ->
       rewriteApp (BVTestBit x (BVValue w (i - j)))
       | otherwise -> pure (boolLitValue False)
 

--- a/base/src/Data/Macaw/CFG/Rewriter.hs
+++ b/base/src/Data/Macaw/CFG/Rewriter.hs
@@ -511,13 +511,10 @@ rewriteApp app = do
       rewriteApp (BVTestBit x (BVValue w (j + i)))
       | otherwise -> pure (boolLitValue False)
     BVTestBit (valueAsApp -> Just (BVSar w x (BVValue _ j))) (BVValue _ i)
-      | j + i < intValue w ->
-      rewriteApp (BVTestBit x (BVValue w (j + i)))
-      | i < intValue w ->
-      rewriteApp (BVTestBit x (BVValue w (intValue w - 1)))
+      | i < intValue w -> do
+      rewriteApp (BVTestBit x (BVValue w (min (j + i) (intValue w-1))))
     BVTestBit (valueAsApp -> Just (BVShl w x (BVValue _ j))) (BVValue _ i)
-      | j <= i ->
-      rewriteApp (BVTestBit x (BVValue w (i - j)))
+      | j <= i -> rewriteApp (BVTestBit x (BVValue w (i - j)))
       | otherwise -> pure (boolLitValue False)
 
     BVComplement w (BVValue _ x) -> do

--- a/base/src/Data/Macaw/CFG/Rewriter.hs
+++ b/base/src/Data/Macaw/CFG/Rewriter.hs
@@ -516,7 +516,7 @@ rewriteApp app = do
       | i < intValue w -> pure (boolLitValue True)
       | otherwise -> pure (boolLitValue False)
     BVTestBit (valueAsApp -> Just (BVShl w x (BVValue _ j))) (BVValue _ i)
-      | 0 <= i - j && i <= intValue w ->
+      | 0 <= i - j && i < intValue w ->
       rewriteApp (BVTestBit x (BVValue w (i - j)))
       | otherwise -> pure (boolLitValue False)
 


### PR DESCRIPTION
I think all three of the shifts were erroneous in different ways -- 'BVTestBit' should be 0 when the index is larger than the width of the word. 

Edit: I was wrong; the only bug was the logical shift left case.