### PR TITLE
[macaw-ppc] Update test expectations for number of discovered blocks.

### DIFF
--- a/macaw-ppc/tests/PPC64InstructionCoverage.hs
+++ b/macaw-ppc/tests/PPC64InstructionCoverage.hs
@@ -56,4 +56,4 @@ testMacaw fpath elf = do
   when (FP.takeFileName fpath == "gzip") $
     -- This is pretty specific, and mostly just designed to notify us
     -- when there has been a change
-    T.assertEqual "number of found blocks" 37218 (length allFoundBlockAddrs)
+    T.assertEqual "number of found blocks" 37211 (length allFoundBlockAddrs)


### PR DESCRIPTION
This change is probably due to the BitTrie modifications in
dismantle-tablegen.  It's not clear whether the older or newer number
of discovered blocks is correct; testing at this point is focused more
on getting roughly the correct order of magnitude rather than being
refined enough for high precision values.