### PR TITLE
x86: Add semantics for the endbr instructions

### DIFF
--- a/x86/src/Data/Macaw/X86/Semantics.hs
+++ b/x86/src/Data/Macaw/X86/Semantics.hs
@@ -2932,6 +2932,8 @@ all_instructions =
       exec_mul v
   , def_neg
   , defNullary  "nop"   $ return ()
+  , defNullary  "endbr32" $ return ()
+  , defNullary  "endbr64" $ return ()
   , defUnary "not"   $ \_ val -> do
       SomeBV l <- getSomeBVLocation val
       modify l bvComplement


### PR DESCRIPTION
This change treats them as no-ops (which is what they do on all released
hardware).  We could represent them with arch extensions.  This has a supporting
change in flexdis86 (included as a submodule).