### PR TITLE
x86: Add semantics for some AVX2 instructions

### DIFF
--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -381,6 +381,7 @@ transferAbsValue r f =
     VOp2 {} -> TopV
     Pointwise2 {} -> TopV
     PointwiseShiftL {} -> TopV
+    PointwiseLogicalShiftR {} -> TopV
     VExtractF128 {} -> TopV
     VInsert {} -> TopV
 

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -665,7 +665,7 @@ data X86PrimFn f tp where
   -- | Shift right each element in the vector by the given amount.
   -- The new ("shifted-in") bits are 0.
   --
-  -- For the expression @PointwiseShiftR n w amtw vec amt@:
+  -- For the expression @PointwiseShiftLogicalR n w amtw vec amt@:
   --
   -- * @n@ is the number of elements in the vector
   -- * @w@ is the size of each element in bits

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -662,6 +662,24 @@ data X86PrimFn f tp where
                   -> !(f (BVType sz))
                   -> X86PrimFn f (BVType (elNum * elSize))
 
+  -- | Shift right each element in the vector by the given amount.
+  -- The new ("shifted-in") bits are 0.
+  --
+  -- For the expression @PointwiseShiftR n w amtw vec amt@:
+  --
+  -- * @n@ is the number of elements in the vector
+  -- * @w@ is the size of each element in bits
+  -- * @amtw@ is the size of the shift amount in bits
+  -- * @vec@ is the vector to be inserted into
+  -- * @amt@ is the shift amount in bits
+  PointwiseLogicalShiftR :: (1 <= elSize, 1 <= elNum, 1 <= sz) =>
+                            !(NatRepr elNum)
+                         -> !(NatRepr elSize)
+                         -> !(NatRepr sz)
+                         -> !(f (BVType (elNum * elSize)))
+                         -> !(f (BVType sz))
+                         -> X86PrimFn f (BVType (elNum * elSize))
+
   -- | Pointwise binary operation on vectors. Should not have side effects.
   --
   -- For the expression @Pointwise2 n w op vec1 vec2@:
@@ -723,6 +741,7 @@ instance HasRepr (X86PrimFn f) TypeRepr where
       X87_FMul{} -> knownRepr
       X87_FST tp _ -> FloatTypeRepr (typeRepr tp)
       PointwiseShiftL n w _ _ _ -> packedAVX n w
+      PointwiseLogicalShiftR n w _ _ _ -> packedAVX n w
       VInsert n w _ _ _ -> packedAVX n w
       VOp1 w _ _ -> BVTypeRepr w
       VOp2 w _ _ _ -> BVTypeRepr w
@@ -779,6 +798,7 @@ instance TraversableFC X86PrimFn where
       VOp1 w o x   -> VOp1 w o <$> go x
       VOp2 w o x y -> VOp2 w o <$> go x <*> go y
       PointwiseShiftL e n s x y -> PointwiseShiftL e n s <$> go x <*> go y
+      PointwiseLogicalShiftR e n s x y -> PointwiseLogicalShiftR e n s <$> go x <*> go y
       Pointwise2 n w o x y -> Pointwise2 n w o <$> go x <*> go y
       VExtractF128 x i -> (`VExtractF128` i) <$> go x
       VInsert n w v e i -> (\v' e' -> VInsert n w v' e' i) <$> go v <*> go e
@@ -831,6 +851,8 @@ instance IsArchFn X86PrimFn where
       VOp2 _ o x y -> sexprA (show o) [ pp x, pp y ]
       PointwiseShiftL _ w _ x y -> sexprA "pointwiseShiftL"
                                      [ ppShow (widthVal w), pp x, pp y ]
+      PointwiseLogicalShiftR _ w _ x y -> sexprA "pointwiseLogicalShiftR"
+                                            [ ppShow (widthVal w), pp x, pp y ]
       Pointwise2 _ w o x y -> sexprA (show o)
                                 [ ppShow (widthVal w) , pp x , pp y ]
       VExtractF128 x i -> sexprA "vextractf128" [ pp x, ppShow i ]
@@ -882,6 +904,7 @@ x86PrimFnHasSideEffects f =
     VOp1 {} -> False
     VOp2 {} -> False
     PointwiseShiftL {} -> False
+    PointwiseLogicalShiftR {} -> False
     Pointwise2 {} -> False
     VExtractF128 {} -> False
     VInsert {} -> False

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -221,7 +221,7 @@ all_instructions =
   , avxPointwise2 "vpaddd" PtAdd n32
   , avxPointwise2 "vpaddq" PtAdd n64
 
-  , avxPointwise2 "vpsubd" PtAdd n32
+  , avxPointwise2 "vpsubd" PtSub n32
 
   , avxOp2 "vpand" VPAnd
   , avxOp2 "vpor" VPOr

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -143,6 +143,20 @@ avxPointwiseShiftL mnem sz =
                   arg1 <~ PointwiseShiftL elN sz amtw v a
              _ -> fail ("[" ++ mnem ++ "]: invalid arguments")
 
+avxPointwiseLogicalShiftR :: (1 <= n) => String -> NatRepr n -> InstructionDef
+avxPointwiseLogicalShiftR mnem sz =
+  avx3 mnem $ \arg1 arg2 arg3 ->
+      do SomeBV vec <- getSomeBVValue arg2
+         SomeBV amt <- getSomeBVValue arg3
+         let vw   = typeWidth vec
+             amtw = typeWidth amt
+         withDivModNat vw sz $ \elN remi ->
+           case (testEquality remi n0, testLeq n1 elN) of
+             (Just Refl, Just LeqProof) ->
+               do v <- eval vec
+                  a <- eval amt
+                  arg1 <~ PointwiseLogicalShiftR elN sz amtw v a
+             _ -> fail ("[" ++ mnem ++ "]: invalid arguments")
 
 avxInsert :: String -> InstructionDef
 avxInsert mnem =
@@ -196,6 +210,9 @@ all_instructions =
 
   , avxPointwiseShiftL "vpslld" n32
   , avxPointwiseShiftL "vpsllq" n64
+
+  , avxPointwiseLogicalShiftR "vpsrld" n32
+  , avxPointwiseLogicalShiftR "vpsrlq" n64
 
   , avxOp1I "vpslldq" VShiftL
   , avxOp1I "vpsrldq" VShiftR

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -219,6 +219,8 @@ all_instructions =
   , avxOp1I "vpshufd" VShufD
 
   , avxPointwise2 "vpaddd" PtAdd n32
+  , avxPointwise2 "vpaddq" PtAdd n64
+
   , avxPointwise2 "vpsubd" PtAdd n32
 
   , avxOp2 "vpand" VPAnd

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -414,6 +414,11 @@ pureSem sym fn = do
          vecOp1 sym LittleEndian (natMultiply elNum elSz) elSz bits $ \xs ->
               fmap (\x -> bvShiftL elSz shSz x amt') xs
 
+    M.PointwiseLogicalShiftR elNum elSz shSz bits amt ->
+      do amt' <- getBitVal (symIface sym) amt
+         vecOp1 sym LittleEndian (natMultiply elNum elSz) elSz bits $ \xs ->
+              fmap (\x -> bvLogicalShiftR elSz shSz x amt') xs
+
     M.Pointwise2 elNum elSz op v1 v2 ->
       vecOp2 sym LittleEndian (natMultiply elNum elSz) elSz v1 v2 $ \xs ys ->
         V.zipWith (semPointwise op elSz) xs ys
@@ -791,6 +796,14 @@ bvShiftL w i vw vi = app (BVShl w vw amt)
                 NatCaseLT LeqProof -> app (BVZext w i vi)
                 NatCaseGT LeqProof -> app (BVTrunc w i vi)
 
+bvLogicalShiftR :: (1 <= w, 1 <= i) =>
+  NatRepr w -> NatRepr i ->
+  E sym (BVType w) -> E sym (BVType i) -> E sym (BVType w)
+bvLogicalShiftR w i vw vi = app (BVLshr w vw amt)
+  where amt = case testNatCases i w of
+                NatCaseEQ -> vi
+                NatCaseLT LeqProof -> app (BVZext w i vi)
+                NatCaseGT LeqProof -> app (BVTrunc w i vi)
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
(The corresponding Flexdis86 PR is at GaloisInc/flexdis86#26.)

This PR adds semantics for `vpsrld`, `vpsrlq`, and `vpaddq`.

As an aside, `vpsubd` is currently defined with `avxPointwise2 "vpsubd" PtAdd n32`, which looks suspiciously like it should be `avxPointwise2 "vpsubd" PtSub n32` instead, but maybe I'm missing some wiring somewhere. I've included that change here for now, but I'm amenable to slicing it into its own PR if it's liable to break anything.