### PR TITLE
x86: Add semantics for vpunpckhqdq, vxorps, vpaddb, and movbe

### DIFF
--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -253,7 +253,8 @@ data AVXOp2 = VPAnd             -- ^ Bitwise and
               -- This one is for DQ, i.e., 64-bit things
               -- but there are equivalents for all sizes, so we should
               -- probably parameterize on size.
-
+            | VPUnpackHQDQ
+              -- ^ @A,B,C,D + P,Q,R,S = A,P,B,Q@
 
 data AVXPointWiseOp2 =
     PtAdd -- ^ Pointwise add;  overflow wraps around; no overflow flags
@@ -276,6 +277,7 @@ instance Show AVXOp2 where
              VAESEncLast  -> "vaesenclast"
              VPCLMULQDQ i -> "vpclmulqdq_" ++ show i
              VPUnpackLQDQ -> "vpunpacklqdq"
+             VPUnpackHQDQ -> "vpunpackhqdq"
 
 instance Show AVXPointWiseOp2 where
   show x = case x of

--- a/x86/src/Data/Macaw/X86/Semantics.hs
+++ b/x86/src/Data/Macaw/X86/Semantics.hs
@@ -319,6 +319,13 @@ def_bswap = defUnary "bswap" $ \_ val -> do
   v0 <- get l
   l .= (bvUnvectorize (typeWidth l) $ reverse $ bvVectorize n8 v0)
 
+def_movbe :: InstructionDef
+def_movbe = defBinary "movbe" $ \_ loc val -> do
+  SomeBV l <- getSomeBVLocation loc
+  SomeBV v <- getSomeBVLocation val
+  v0 <- get v
+  l .= bvUnvectorize (typeWidth l) (reverse $ bvVectorize n8 v0)
+
 def_xadd :: InstructionDef
 def_xadd =
   defBinaryLL "xadd" $ \_ d s -> do
@@ -2913,6 +2920,7 @@ all_instructions =
   , def_bsf
   , def_bsr
   , def_bswap
+  , def_movbe
   , def_cbw
   , def_cwde
   , def_cdqe

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -218,6 +218,7 @@ all_instructions =
   , avxOp1I "vpsrldq" VShiftR
   , avxOp1I "vpshufd" VShufD
 
+  , avxPointwise2 "vpaddb" PtAdd n8
   , avxPointwise2 "vpaddd" PtAdd n32
   , avxPointwise2 "vpaddq" PtAdd n64
 
@@ -227,11 +228,13 @@ all_instructions =
   , avxOp2 "vpor" VPOr
   , avxOp2 "vpxor" VPXor
   , avxOp2 "vpshufb" VPShufB
+  , avxOp2 "vxorps" VPXor
 
   , avxOp2I "vpalignr" VPAlignR
 
   , avxOp2 "vaesenc" VAESEnc
   , avxOp2 "vaesenclast" VAESEncLast
+
   , avxOp2 "vpunpcklqdq" VPUnpackLQDQ
   , avxOp2 "vpunpckhqdq" VPUnpackHQDQ
 

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -10,7 +10,7 @@ import Data.Parameterized.Some
 import qualified Flexdis86 as F
 
 import Data.Macaw.CFG.Core(Value,bvValue)
-import Data.Macaw.Types(BVType,typeWidth,n0,n1,n32,n64,n128, n256)
+import Data.Macaw.Types(BVType,typeWidth,n0,n1,n8,n32,n64,n128,n256)
 
 import Data.Macaw.X86.InstructionDef
 import Data.Macaw.X86.Monad((.=), uext, subRegister)

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -233,6 +233,7 @@ all_instructions =
   , avxOp2 "vaesenc" VAESEnc
   , avxOp2 "vaesenclast" VAESEncLast
   , avxOp2 "vpunpcklqdq" VPUnpackLQDQ
+  , avxOp2 "vpunpckhqdq" VPUnpackHQDQ
 
   , avx3 "vextractf128" $ \arg1 arg2 arg ->
       do SomeBV vec <- getSomeBVValue arg2

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -382,6 +382,10 @@ pureSem sym fn = do
                     in case mul2Plus n of
                          Refl -> V.take n (PV.interleave xs ys)
 
+        M.VPUnpackHQDQ -> vecOp2 sym BigEndian w (knownNat @64) x y $
+          \xs ys -> let n = V.length xs
+                    in case mul2Plus n of
+                         Refl -> V.take n (PV.interleave xs ys)
 
         M.VAESEnc
           | Just Refl <- testEquality w n128 ->


### PR DESCRIPTION
The corresponding decodings are introduced in GaloisInc/flexdis86#27.