### PR TITLE
Feature/aarch32 symbolic backend

### DIFF
--- a/macaw-aarch32-symbolic/macaw-aarch32-symbolic.cabal
+++ b/macaw-aarch32-symbolic/macaw-aarch32-symbolic.cabal
@@ -19,12 +19,21 @@ extra-source-files:  CHANGELOG.md
 
 library
   exposed-modules:     Data.Macaw.AArch32.Symbolic
-  -- other-modules:
+  other-modules:       Data.Macaw.AArch32.Symbolic.AtomWrapper
+                       Data.Macaw.AArch32.Symbolic.Functions
+                       Data.Macaw.AArch32.Symbolic.Panic
   -- other-extensions:
   build-depends:       base >=4.10 && <5,
+                       containers,
+                       lens,
+                       panic,
                        parameterized-utils,
+                       asl-translator,
+                       what4,
                        crucible,
+                       crucible-llvm,
                        macaw-base,
+                       dismantle-arm-xml,
                        semmc-aarch32,
                        macaw-aarch32,
                        macaw-symbolic

--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
@@ -1,39 +1,249 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Data.Macaw.AArch32.Symbolic (
-
+  aarch32MacawSymbolicFns
+  , lookupReg
+  , updateReg
   ) where
 
+import           GHC.TypeLits
+
+import           Control.Lens ( (&), (%~) )
+import           Control.Monad ( void )
+import           Control.Monad.IO.Class ( liftIO )
+import qualified Data.Functor.Identity as I
 import           Data.Kind ( Type )
+import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Symbolic as MS
 import qualified Data.Macaw.Symbolic.Backend as MSB
 import qualified Data.Macaw.Types as MT
 import qualified Data.Parameterized.Context as Ctx
+import qualified Data.Parameterized.CtxFuns as PC
+import qualified Data.Parameterized.Map as MapF
+import qualified Data.Parameterized.TraversableF as TF
 import qualified Data.Parameterized.TraversableFC as FC
-import qualified SemMC.Architecture.AArch32 as SA
+import           Data.Proxy ( Proxy(..) )
+import qualified What4.BaseTypes as WT
+import qualified What4.Symbol as WS
 
+import qualified Language.ASL.Globals as LAG
+import qualified SemMC.Architecture.AArch32 as SA
+import qualified Data.Macaw.ARM.Arch as MAA
+import qualified Data.Macaw.ARM.ARMReg as MAR
+
+import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.CFG.Extension as CE
+import qualified Lang.Crucible.CFG.Reg as CR
+import qualified Lang.Crucible.Simulator.RegMap as MCR
+import qualified Lang.Crucible.Simulator.RegValue as MCRV
 import qualified Lang.Crucible.Types as CT
 
+import qualified Data.Macaw.AArch32.Symbolic.AtomWrapper as AA
+import qualified Data.Macaw.AArch32.Symbolic.Functions as AF
+import qualified Data.Macaw.AArch32.Symbolic.Panic as AP
+
+aarch32MacawSymbolicFns :: MS.MacawSymbolicArchFunctions SA.AArch32
+aarch32MacawSymbolicFns =
+  MSB.MacawSymbolicArchFunctions
+  { MSB.crucGenArchConstraints = \x -> x
+  , MSB.crucGenArchRegName = aarch32RegName
+  , MSB.crucGenRegAssignment = aarch32RegAssignment
+  , MSB.crucGenRegStructType = aarch32RegStructType
+  , MSB.crucGenArchFn = aarch32GenFn
+  , MSB.crucGenArchStmt = aarch32GenStmt
+  , MSB.crucGenArchTermStmt = aarch32GenTermStmt
+  }
+
+aarch32RegName :: MAR.ARMReg tp -> WS.SolverSymbol
+aarch32RegName r = WS.systemSymbol ("r!" ++ show (MC.prettyF r))
+
+aarch32MacawEvalFn :: (CB.IsSymInterface sym)
+                   => AF.SymFuns sym
+                   -> MS.MacawArchEvalFn sym mem SA.AArch32
+aarch32MacawEvalFn fs = MSB.MacawArchEvalFn $ \_ _ xt s ->
+  case xt of
+    AArch32PrimFn p -> AF.funcSemantics fs p s
+    AArch32PrimStmt p -> AF.stmtSemantics fs p s
+    AArch32PrimTerm p -> AF.termSemantics fs p s
+
 instance MS.ArchInfo SA.AArch32 where
-  archVals _ = Nothing
+  archVals _ = Just $ MS.ArchVals
+               { MS.archFunctions = aarch32MacawSymbolicFns
+               , MS.withArchEval = \sym k -> do
+                   sfns <- liftIO $ AF.newSymFuns sym
+                   k (aarch32MacawEvalFn sfns)
+               , MS.withArchEvalTrace = error "Removing withArchEvalTrace"
+               , MS.withArchConstraints = \x -> x
+               , MS.lookupReg = aarch32LookupReg
+               , MS.updateReg = aarch32UpdateReg
+               }
 
 data AArch32StmtExtension (f :: CT.CrucibleType -> Type) (ctp :: CT.CrucibleType) where
+  AArch32PrimFn :: MAA.ARMPrimFn (AA.AtomWrapper f) t -> AArch32StmtExtension f (MS.ToCrucibleType t)
+  AArch32PrimStmt :: MAA.ARMStmt (AA.AtomWrapper f) -> AArch32StmtExtension f CT.UnitType
+  AArch32PrimTerm :: MAA.ARMTermStmt ids -> AArch32StmtExtension f CT.UnitType
 
 instance FC.FunctorFC AArch32StmtExtension where
+  fmapFC f st =
+    case st of
+      AArch32PrimFn p -> AArch32PrimFn (FC.fmapFC (AA.liftAtomMap f) p)
+      AArch32PrimStmt p -> AArch32PrimStmt (TF.fmapF (AA.liftAtomMap f) p)
+      AArch32PrimTerm p -> AArch32PrimTerm p
+
 instance FC.FoldableFC AArch32StmtExtension where
+  foldMapFC f st =
+    case st of
+      AArch32PrimFn p -> FC.foldMapFC (AA.liftAtomIn f) p
+      AArch32PrimStmt p -> TF.foldMapF (AA.liftAtomIn f) p
+      -- There is no data in terminators for now, so we can have a trivial implementation
+      AArch32PrimTerm _p -> mempty
+
 instance FC.TraversableFC AArch32StmtExtension where
+  traverseFC f st =
+    case st of
+      AArch32PrimFn p -> AArch32PrimFn <$> FC.traverseFC (AA.liftAtomTrav f) p
+      AArch32PrimStmt p -> AArch32PrimStmt <$> TF.traverseF (AA.liftAtomTrav f) p
+      AArch32PrimTerm p -> pure (AArch32PrimTerm p)
+
 instance CE.TypeApp AArch32StmtExtension where
+  appType st =
+    case st of
+      AArch32PrimFn p -> MS.typeToCrucible (MT.typeRepr p)
+      AArch32PrimStmt _p -> CT.UnitRepr
+      AArch32PrimTerm _p -> CT.UnitRepr
+
 instance CE.PrettyApp AArch32StmtExtension where
+  ppApp ppSub st =
+    case st of
+      AArch32PrimFn p ->
+        I.runIdentity (MC.ppArchFn (I.Identity . AA.liftAtomIn ppSub) p)
+      AArch32PrimStmt p ->
+        MC.ppArchStmt (AA.liftAtomIn ppSub) p
+      AArch32PrimTerm p -> MC.prettyF p
 
 type instance MSB.MacawArchStmtExtension SA.AArch32 =
   AArch32StmtExtension
 
--- Dummy register context
+-- | All of the registers tracked in the AArch32 machine code model
 --
--- For now, just add one register
-type RegContext = Ctx.EmptyCtx Ctx.::> MT.BVType 32
+-- Note that this set is significantly larger than the user-visible
+-- architectural state and includes a large number of hidden state from the ASL
+-- semantics
+--
+-- See Note [ARM Registers]
+type RegContext = PC.MapCtx ToMacawTypeWrapper LAG.GlobalsCtx
 type instance MS.ArchRegContext SA.AArch32 = RegContext
+
+data ToMacawTypeWrapper :: PC.TyFun WT.BaseType MT.Type -> Type
+type instance PC.Apply ToMacawTypeWrapper t = BaseToMacawType t
+
+aarch32RegAssignment :: Ctx.Assignment MAR.ARMReg RegContext
+aarch32RegAssignment =
+  I.runIdentity (PC.traverseMapCtx (Proxy @AsMacawReg) asARMReg LAG.allGlobalRefs)
+
+data AsMacawReg :: PC.TyFun Symbol MT.Type -> Type
+type instance PC.Apply AsMacawReg s = BaseToMacawType (LAG.GlobalsType s)
+
+asARMReg :: (Monad m) => LAG.GlobalRef s -> m (MAR.ARMReg (BaseToMacawType (LAG.GlobalsType s)))
+asARMReg gr =
+  case LAG.globalRefRepr gr of
+    WT.BaseBoolRepr -> return (MAR.ARMGlobalBool gr)
+    WT.BaseBVRepr _ -> return (MAR.ARMGlobalBV gr)
+    WT.BaseStructRepr Ctx.Empty -> return MAR.ARMDummyReg
+    tp -> AP.panic AP.AArch32 "asARMReg" ["Unexpected type: " ++ show tp]
+
+type family BaseToMacawType (t :: WT.BaseType) :: MT.Type where
+  BaseToMacawType WT.BaseBoolType = MT.BoolType
+  BaseToMacawType (WT.BaseBVType n) = MT.BVType n
+  BaseToMacawType (WT.BaseStructType Ctx.EmptyCtx) = MT.TupleType '[]
+
+aarch32RegStructType :: CT.TypeRepr (MS.ArchRegStruct SA.AArch32)
+aarch32RegStructType =
+  CT.StructRepr (MS.typeCtxToCrucible (FC.fmapFC MT.typeRepr aarch32RegAssignment))
+
+aarch32GenFn :: MAA.ARMPrimFn (MC.Value SA.AArch32 ids) tp
+             -> MSB.CrucGen SA.AArch32 ids s (CR.Atom s (MS.ToCrucibleType tp))
+aarch32GenFn fn = do
+  let f x = AA.AtomWrapper <$> MSB.valueToCrucible x
+  r <- FC.traverseFC f fn
+  MSB.evalArchStmt (AArch32PrimFn r)
+
+aarch32GenStmt :: MAA.ARMStmt (MC.Value SA.AArch32 ids)
+               -> MSB.CrucGen SA.AArch32 ids s ()
+aarch32GenStmt s = do
+  let f x = AA.AtomWrapper <$> MSB.valueToCrucible x
+  s' <- TF.traverseF f s
+  void (MSB.evalArchStmt (AArch32PrimStmt s'))
+
+aarch32GenTermStmt :: MAA.ARMTermStmt ids
+                   -> MC.RegState MAR.ARMReg (MC.Value SA.AArch32 ids)
+                   -> MSB.CrucGen SA.AArch32 ids s ()
+aarch32GenTermStmt ts _regs =
+  void (MSB.evalArchStmt (AArch32PrimTerm ts))
+
+regIndexMap :: MSB.RegIndexMap SA.AArch32
+regIndexMap = MSB.mkRegIndexMap asgn sz
+  where
+    asgn = aarch32RegAssignment
+    sz = Ctx.size (MS.typeCtxToCrucible (FC.fmapFC MT.typeRepr asgn))
+
+updateReg :: MAR.ARMReg tp
+          -> (f (MS.ToCrucibleType tp) -> f (MS.ToCrucibleType tp))
+          -> Ctx.Assignment f (MS.MacawCrucibleRegTypes SA.AArch32)
+          -> Ctx.Assignment f (MS.MacawCrucibleRegTypes SA.AArch32)
+updateReg reg upd asgn =
+  case MapF.lookup reg regIndexMap of
+    Just pair -> asgn & MapF.ixF (MSB.crucibleIndex pair) %~ upd
+    Nothing -> AP.panic AP.AArch32 "updateReg" ["Missing reg entry for register: " ++ show reg]
+
+aarch32UpdateReg :: MCR.RegEntry sym (MS.ArchRegStruct SA.AArch32)
+                 -> MAR.ARMReg tp
+                 -> MCRV.RegValue sym (MS.ToCrucibleType tp)
+                 -> MCR.RegEntry sym (MS.ArchRegStruct SA.AArch32)
+aarch32UpdateReg regs reg val =
+  regs { MCR.regValue = updateReg reg (const (MCRV.RV val)) (MCR.regValue regs) }
+
+lookupReg :: MAR.ARMReg tp
+          -> Ctx.Assignment f (MS.MacawCrucibleRegTypes SA.AArch32)
+          -> f (MS.ToCrucibleType tp)
+lookupReg reg regs =
+  case MapF.lookup reg regIndexMap of
+    Just pair -> regs Ctx.! MSB.crucibleIndex pair
+    Nothing -> AP.panic AP.AArch32 "lookupReg" ["Missing reg entry for register: " ++ show reg]
+
+aarch32LookupReg :: MCR.RegEntry sym (MS.ArchRegStruct SA.AArch32)
+                 -> MAR.ARMReg tp
+                 -> MCR.RegEntry sym (MS.ToCrucibleType tp)
+aarch32LookupReg regs reg =
+  case lookupReg reg (MCR.regValue regs) of
+    MCRV.RV val -> MCR.RegEntry (MS.typeToCrucible (MT.typeRepr reg)) val
+
+{- Note [ARM Registers]
+
+The symbolic execution (and the code discovery in macaw-aarch32) track a
+superset of the user-visible architectural state, which only includes the GPRs
+and SIMD registers.  The extended state includes low-level architectural details
+referenced by the ASL semantics.
+
+In asl-translator, the set of architectural state is referred to as the
+"tracked" registers (or allGlobalRefs).  This is state that must be maintained
+during code discovery and symbolic execution, which includes things like:
+
+- The IT state
+- Branch taken/not taken flags
+- Various flags
+
+Note that there are "untracked" state, which is architectural state referred to
+in the semantics, but that is entirely local to an instruction.  These are
+equivalent to local variables and do not appear in the post states of any
+instructions.  We do not track those in the symbolic execution because they are
+effectively inlined when we symbolically execute the ASL semantics into formulas
+for semmc.
+
+-}

--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/AtomWrapper.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/AtomWrapper.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+module Data.Macaw.AArch32.Symbolic.AtomWrapper (
+  AtomWrapper(..),
+  liftAtomMap,
+  liftAtomTrav,
+  liftAtomIn
+  ) where
+
+import           Data.Kind ( Type )
+
+import qualified Lang.Crucible.Types as C
+import qualified Data.Macaw.Types as MT
+import qualified Data.Macaw.Symbolic as MS
+
+newtype AtomWrapper (f :: C.CrucibleType -> Type) (tp :: MT.Type)
+  = AtomWrapper (f (MS.ToCrucibleType tp))
+
+liftAtomMap :: (forall s. f s -> g s) -> AtomWrapper f t -> AtomWrapper g t
+liftAtomMap f (AtomWrapper x) = AtomWrapper (f x)
+
+liftAtomTrav ::
+  Functor m =>
+  (forall s. f s -> m (g s)) -> (AtomWrapper f t -> m (AtomWrapper g t))
+liftAtomTrav f (AtomWrapper x) = AtomWrapper <$> f x
+
+liftAtomIn :: (forall s. f s -> a) -> AtomWrapper f t -> a
+liftAtomIn f (AtomWrapper x) = f x
+
+

--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Functions.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Functions.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+module Data.Macaw.AArch32.Symbolic.Functions (
+  SymFuns
+  , newSymFuns
+  , funcSemantics
+  , stmtSemantics
+  , termSemantics
+  -- * Exceptions
+  , AArch32Exception(..)
+  ) where
+
+import qualified Control.Exception as X
+import           Control.Lens ( (^.) )
+import qualified Data.IORef as IOR
+import qualified Data.Map.Strict as Map
+import qualified Data.Parameterized.Classes as PC
+import qualified Data.Parameterized.Context as Ctx
+import           Text.Printf ( printf )
+
+import qualified Data.Macaw.Symbolic as MS
+import qualified Data.Macaw.Types as MT
+import qualified Lang.Crucible.Backend as CB
+import qualified Lang.Crucible.LLVM.MemModel as LL
+import qualified Lang.Crucible.Simulator as CS
+import qualified Lang.Crucible.Simulator.ExecutionTree as CSET
+import qualified Lang.Crucible.Types as CT
+import qualified What4.BaseTypes as WT
+import qualified What4.Interface as WI
+import qualified What4.Symbol as WS
+
+import qualified Data.Macaw.AArch32.Symbolic.AtomWrapper as AA
+import qualified Data.Macaw.AArch32.Symbolic.Panic as AP
+import qualified Data.Macaw.ARM.Arch as MAA
+import qualified Dismantle.ARM.A32 as ARMDis
+import qualified SemMC.Architecture.AArch32 as SA
+
+data SomeSymFun sym where
+  SomeSymFun :: Ctx.Assignment WT.BaseTypeRepr ps -> WT.BaseTypeRepr r -> WI.SymFn sym ps r -> SomeSymFun sym
+
+data SymFuns sym =
+  SymFuns { symFuns :: IOR.IORef (Map.Map String (SomeSymFun sym))
+          }
+
+data AArch32Exception where
+  MissingSemanticsForInstruction :: ARMDis.Opcode ARMDis.Operand s -> AArch32Exception
+  MissingSemanticsForFunction :: String -> AArch32Exception
+  UnsupportedSyscall :: AArch32Exception
+
+deriving instance Show AArch32Exception
+instance X.Exception AArch32Exception
+
+newSymFuns :: (CB.IsSymInterface sym) => sym -> IO (SymFuns sym)
+newSymFuns _sym = do
+  r <- IOR.newIORef Map.empty
+  return SymFuns { symFuns = r }
+
+type S sym rtp bs r ctx = CS.CrucibleState (MS.MacawSimulatorState sym) sym (MS.MacawExt SA.AArch32) rtp bs r ctx
+
+-- | Semantics for ARM-specific block terminators
+--
+-- Right now we only have one: system call.  This will eventually need to
+-- inspect the current register state in order to determine what system call was
+-- issued under the ABI.
+--
+-- It is not currently clear where that information might come from (it is
+-- implicitly in 'S', but might be hard to dig out).  It would probably be
+-- easier to just include the necessary register snapshot in the terminator (and
+-- traverse them appropriately to translate into Crucible terms)
+termSemantics :: (CB.IsSymInterface sym)
+              => SymFuns sym
+              -> MAA.ARMTermStmt ids
+              -> S sym rtp bs r ctx
+              -> IO (CS.RegValue sym CT.UnitType, S sym rtp bs r ctx)
+termSemantics _sfns tstmt _st0 =
+  case tstmt of
+    MAA.ARMSyscall _payload ->
+      X.throwIO UnsupportedSyscall
+
+-- | Semantics for statement syntax extensions
+--
+-- Right now, there is only one statement, which represents instructions for which we lack semantics.
+-- All we can do for this is stop symbolic execution and report that to the caller (so that semantics
+-- can be added).
+stmtSemantics :: (CB.IsSymInterface sym)
+              => SymFuns sym
+              -> MAA.ARMStmt (AA.AtomWrapper (CS.RegEntry sym))
+              -> S sym rtp bs r ctx
+              -> IO (CS.RegValue sym CT.UnitType, S sym rtp bs r ctx)
+stmtSemantics _sfns stmt _st0 =
+  case stmt of
+    MAA.UninterpretedOpcode opc _ops ->
+      X.throwIO (MissingSemanticsForInstruction opc)
+
+funcSemantics :: (CB.IsSymInterface sym, MS.ToCrucibleType mt ~ t)
+              => SymFuns sym
+              -> MAA.ARMPrimFn (AA.AtomWrapper (CS.RegEntry sym)) mt
+              -> S sym rtp bs r ctx
+              -> IO (CS.RegValue sym t, S sym rtp bs r ctx)
+funcSemantics sfns fn st0 =
+  case fn of
+    MAA.SDiv _rep lhs rhs -> withSym st0 $ \sym -> do
+      lhs' <- toValBV sym lhs
+      rhs' <- toValBV sym rhs
+      -- NOTE: We are applying division directly here without checking the divisor for zero.
+      --
+      -- The ARM semantics explicitly check this and have different behaviors
+      -- depending on what CPU flags are set; this operation is never called
+      -- with a divisor of zero.  We could add an assertion to that effect here,
+      -- but it might be difficult to prove.
+      LL.llvmPointer_bv sym =<< WI.bvSdiv sym lhs' rhs'
+    MAA.UDiv _rep lhs rhs -> withSym st0 $ \sym -> do
+      lhs' <- toValBV sym lhs
+      rhs' <- toValBV sym rhs
+      -- NOTE: See the note in SDiv
+      LL.llvmPointer_bv sym =<< WI.bvUdiv sym lhs' rhs'
+    MAA.URem _rep lhs rhs -> withSym st0 $ \sym -> do
+      lhs' <- toValBV sym lhs
+      rhs' <- toValBV sym rhs
+      -- NOTE: See the note in SDiv
+      LL.llvmPointer_bv sym =<< WI.bvUrem sym lhs' rhs'
+    MAA.SRem _rep lhs rhs -> withSym st0 $ \sym -> do
+      lhs' <- toValBV sym lhs
+      rhs' <- toValBV sym rhs
+      -- NOTE: See the note in SDiv
+      LL.llvmPointer_bv sym =<< WI.bvSrem sym lhs' rhs'
+    MAA.UnsignedRSqrtEstimate _rep v -> withSym st0 $ \sym -> do
+      v' <- toValBV sym v
+      let args = Ctx.empty Ctx.:> v'
+      res <- lookupApplySymFun sym sfns "unsignedRSqrtEstimate" CT.knownRepr args CT.knownRepr
+      LL.llvmPointer_bv sym res
+    MAA.FPSub {} -> X.throwIO (MissingSemanticsForFunction "FPSub")
+    MAA.FPAdd {} -> X.throwIO (MissingSemanticsForFunction "FPAdd")
+    MAA.FPMul {} -> X.throwIO (MissingSemanticsForFunction "FPMul")
+    MAA.FPDiv {} -> X.throwIO (MissingSemanticsForFunction "FPDiv")
+    MAA.FPRecipEstimate {} -> X.throwIO (MissingSemanticsForFunction "FPRecipEstimate")
+    MAA.FPRecipStep {} -> X.throwIO (MissingSemanticsForFunction "FPRecipStep")
+    MAA.FPSqrtEstimate {} -> X.throwIO (MissingSemanticsForFunction "FPSqrtEstimate")
+    MAA.FPRSqrtStep {} -> X.throwIO (MissingSemanticsForFunction "FPRSqrtStep")
+    MAA.FPSqrt {} -> X.throwIO (MissingSemanticsForFunction "FPSqrt")
+    MAA.FPMax {} -> X.throwIO (MissingSemanticsForFunction "FPMax")
+    MAA.FPMin {} -> X.throwIO (MissingSemanticsForFunction "FPMin")
+    MAA.FPMaxNum {} -> X.throwIO (MissingSemanticsForFunction "FPMaxNum")
+    MAA.FPMinNum {} -> X.throwIO (MissingSemanticsForFunction "FPMinNum")
+    MAA.FPMulAdd {} -> X.throwIO (MissingSemanticsForFunction "FPMulAdd")
+    MAA.FPCompareGE {} -> X.throwIO (MissingSemanticsForFunction "FPCompareGE")
+    MAA.FPCompareGT {} -> X.throwIO (MissingSemanticsForFunction "FPCompareGT")
+    MAA.FPCompareEQ {} -> X.throwIO (MissingSemanticsForFunction "FPCompareEQ")
+    MAA.FPCompareNE {} -> X.throwIO (MissingSemanticsForFunction "FPCompareNE")
+    MAA.FPCompareUN {} -> X.throwIO (MissingSemanticsForFunction "FPCompareUN")
+    MAA.FPToFixed {} -> X.throwIO (MissingSemanticsForFunction "FPToFixed")
+    MAA.FixedToFP {} -> X.throwIO (MissingSemanticsForFunction "FixedToFP")
+    MAA.FPConvert {} -> X.throwIO (MissingSemanticsForFunction "FPConvert")
+    MAA.FPToFixedJS {} -> X.throwIO (MissingSemanticsForFunction "FPToFixedJS")
+    MAA.FPRoundInt {} -> X.throwIO (MissingSemanticsForFunction "FPRoundInt")
+
+withSym :: (CB.IsSymInterface sym)
+        => S sym rtp bs r ctx
+        -> (sym -> IO a)
+        -> IO (a, S sym rtp bs r ctx)
+withSym s action = do
+  let sym = s ^. CSET.stateSymInterface
+  val <- action sym
+  return (val, s)
+
+
+-- | Assert that the wrapped value is a bitvector
+toValBV :: (CB.IsSymInterface sym)
+        => sym
+        -> AA.AtomWrapper (CS.RegEntry sym) (MT.BVType w)
+        -> IO (CS.RegValue sym (CT.BVType w))
+toValBV sym (AA.AtomWrapper x) = LL.projectLLVM_bv sym (CS.regValue x)
+
+-- | Apply an uninterpreted function to the provided arguments
+--
+-- If there is already a function allocated with that name, re-use it.
+-- Otherwise, allocate a fresh function and store it in a persistent mapping
+-- (inside of an IORef)
+lookupApplySymFun :: (CB.IsSymInterface sym)
+                  => sym
+                  -> SymFuns sym
+                  -> String
+                  -> Ctx.Assignment WT.BaseTypeRepr ps
+                  -> Ctx.Assignment (WI.SymExpr sym) ps
+                  -> WT.BaseTypeRepr r
+                  -> IO (WI.SymExpr sym r)
+lookupApplySymFun sym sf name argReprs args retRepr = do
+  r <- IOR.readIORef (symFuns sf)
+  case Map.lookup name r of
+    Just (SomeSymFun argReprs' retRepr' fn)
+      | Just PC.Refl <- PC.testEquality argReprs' argReprs
+      , Just PC.Refl <- PC.testEquality retRepr' retRepr ->
+        WI.applySymFn sym fn args
+      | otherwise ->
+        AP.panic AP.AArch32 "lookupApplySymFun" [printf "Invalid type for symbolic function '%s' expected %s but got %s " name (show (argReprs, retRepr)) (show (argReprs', retRepr'))]
+    Nothing -> do
+      fn <- WI.freshTotalUninterpFn sym (WS.safeSymbol name) argReprs retRepr
+      IOR.modifyIORef (symFuns sf) (Map.insert name (SomeSymFun argReprs retRepr fn))
+      WI.applySymFn sym fn args

--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Panic.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Panic.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Data.Macaw.AArch32.Symbolic.Panic (
+  P.panic,
+  Component(..)
+  ) where
+
+import qualified Panic as P
+
+data Component = AArch32
+  deriving (Show)
+
+instance P.PanicComponent Component where
+  panicComponentName = show
+  panicComponentIssues _ = "https://github.com/GaloisInc/macaw/issues"
+  panicComponentRevision = $(P.useGitRevision)

--- a/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
@@ -123,7 +123,7 @@ data ARMPrimFn (f :: MT.Type -> Type) tp where
        -> f (MT.BVType w)
        -> ARMPrimFn f (MT.BVType w)
 
-  UnsignedRSqrtEstimate :: (1 <= w)
+  UnsignedRSqrtEstimate :: (KnownNat w, 1 <= w)
                         => NR.NatRepr w
                         -> f (MT.BVType w)
                         -> ARMPrimFn f (MT.BVType w)

--- a/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
@@ -355,7 +355,7 @@ instance FCls.TraversableFC ARMPrimFn where
 
 type instance MC.ArchFn ARM.AArch32 = ARMPrimFn
 
-instance MT.HasRepr (ARMPrimFn (MC.Value ARM.AArch32 ids)) MT.TypeRepr where
+instance MT.HasRepr (ARMPrimFn f) MT.TypeRepr where
   typeRepr f =
     case f of
       UDiv rep _ _ -> MT.BVTypeRepr rep


### PR DESCRIPTION
This implements most of the backend for aarch32. It should be enough to use for most cases - it only lacks semantics for the low-level floating point operations.  I'll make a separate ticket about 

Fixes #160 