### PR TITLE
x86: Add some entries to the export list of Data.Macaw.X86

### DIFF
--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -22,12 +22,15 @@ x86_64 programs.
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE NondecreasingIndentation #-}
 module Data.Macaw.X86
-       ( x86_64_freeBSD_info
+       ( x86_64_info
+       , x86_64_freeBSD_info
        , x86_64_linux_info
        , x86_64CallParams
        , freeBSD_syscallPersonality
        , linux_syscallPersonality
          -- * Low level exports
+       , CallParams(..)
+       , ArchitectureInfo(..)
        , X86BlockPrecond(..)
        , ExploreLoc(..)
        , rootLoc


### PR DESCRIPTION
This is useful downstream sometimes, e.g. for customizing the set of caller/callee saved registers.