### PR TITLE
x86: Implement semantics for a few instructions

### DIFF
--- a/x86/macaw-x86.cabal
+++ b/x86/macaw-x86.cabal
@@ -35,6 +35,7 @@ library
     Data.Macaw.X86.Monad
     Data.Macaw.X86.Semantics
     Data.Macaw.X86.Semantics.ADX
+    Data.Macaw.X86.Semantics.AESNI
     Data.Macaw.X86.Semantics.AVX
     Data.Macaw.X86.Semantics.BMI2
     Data.Macaw.X86.SyscallInfo

--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -376,10 +376,13 @@ transferAbsValue r f =
     X87_FSub{}  -> TopV
     X87_FMul{}  -> TopV
 
+    CLMul{} -> TopV
+
     AESNI_AESEnc{} -> TopV
     AESNI_AESEncLast{} -> TopV
     AESNI_AESDec{} -> TopV
     AESNI_AESDecLast{} -> TopV
+    AESNI_AESKeyGenAssist{} -> TopV
 
     -- XXX: Is 'TopV' the right thing for the AVX instruction below?
     VOp1 {} -> TopV

--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -376,6 +376,11 @@ transferAbsValue r f =
     X87_FSub{}  -> TopV
     X87_FMul{}  -> TopV
 
+    AESNI_AESEnc{} -> TopV
+    AESNI_AESEncLast{} -> TopV
+    AESNI_AESDec{} -> TopV
+    AESNI_AESDecLast{} -> TopV
+
     -- XXX: Is 'TopV' the right thing for the AVX instruction below?
     VOp1 {} -> TopV
     VOp2 {} -> TopV

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -259,7 +259,7 @@ data AVXOp2 = VPAnd             -- ^ Bitwise and
 data AVXPointWiseOp2 =
     PtAdd -- ^ Pointwise add;  overflow wraps around; no overflow flags
   | PtSub -- ^ Pointwise subtract; overflow wraps around; no overflow flags
-  | PtCmpGt
+  | PtCmpGt -- ^ Pointwise greater than
 
 instance Show AVXOp1 where
   show x = case x of

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -840,7 +840,7 @@ instance TraversableFC X86PrimFn where
       VInsert n w v e i -> (\v' e' -> VInsert n w v' e' i) <$> go v <*> go e
       CLMul x y -> CLMul <$> go x <*> go y
       AESNI_AESEnc x y -> AESNI_AESEnc <$> go x <*> go y
-      AESNI_AESEncLast x y -> AESNI_AESDec <$> go x <*> go y
+      AESNI_AESEncLast x y -> AESNI_AESEncLast <$> go x <*> go y
       AESNI_AESDec x y -> AESNI_AESDec <$> go x <*> go y
       AESNI_AESDecLast x y -> AESNI_AESDecLast <$> go x <*> go y
       AESNI_AESKeyGenAssist x i -> AESNI_AESKeyGenAssist <$> go x <*> pure i

--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -259,6 +259,7 @@ data AVXOp2 = VPAnd             -- ^ Bitwise and
 data AVXPointWiseOp2 =
     PtAdd -- ^ Pointwise add;  overflow wraps around; no overflow flags
   | PtSub -- ^ Pointwise subtract; overflow wraps around; no overflow flags
+  | PtCmpGt
 
 instance Show AVXOp1 where
   show x = case x of
@@ -283,6 +284,7 @@ instance Show AVXPointWiseOp2 where
   show x = case x of
              PtAdd -> "ptadd"
              PtSub -> "ptsub"
+             PtCmpGt -> "ptcmpgt"
 
 ------------------------------------------------------------------------
 -- X86PrimFn

--- a/x86/src/Data/Macaw/X86/Semantics.hs
+++ b/x86/src/Data/Macaw/X86/Semantics.hs
@@ -8,6 +8,7 @@ This module provides definitions for x86 instructions.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -3076,6 +3077,46 @@ all_instructions =
   , def_fsubrp
   , defNullary "emms" $ addArchStmt EMMS
   , defNullary "femms" $ addArchStmt EMMS
+  , defBinary "aesenc" $ \_ v1 v2 -> do
+      SomeBV state <- getSomeBVLocation v1
+      SomeBV key <- getSomeBVLocation v2
+      if | Just Refl <- testEquality (typeWidth state) (knownNat @128)
+         , Just Refl <- testEquality (typeWidth key) (knownNat @128) -> do
+             s <- eval =<< get state
+             k <- eval =<< get key
+             res <- evalArchFn (AESNI_AESEnc s k)
+             state .= res
+         | otherwise -> fail "aesenc: State and key must be 128-bit"
+  , defBinary "aesenclast" $ \_ v1 v2 -> do
+      SomeBV state <- getSomeBVLocation v1
+      SomeBV key <- getSomeBVLocation v2
+      if | Just Refl <- testEquality (typeWidth state) (knownNat @128)
+         , Just Refl <- testEquality (typeWidth key) (knownNat @128) -> do
+             s <- eval =<< get state
+             k <- eval =<< get key
+             res <- evalArchFn (AESNI_AESEncLast s k)
+             state .= res
+         | otherwise -> fail "aesenclast: State and key must be 128-bit"
+  , defBinary "aesdec" $ \_ v1 v2 -> do
+      SomeBV state <- getSomeBVLocation v1
+      SomeBV key <- getSomeBVLocation v2
+      if | Just Refl <- testEquality (typeWidth state) (knownNat @128)
+         , Just Refl <- testEquality (typeWidth key) (knownNat @128) -> do
+             s <- eval =<< get state
+             k <- eval =<< get key
+             res <- evalArchFn (AESNI_AESDec s k)
+             state .= res
+         | otherwise -> fail "aesdec: State and key must be 128-bit"
+  , defBinary "aesdeclast" $ \_ v1 v2 -> do
+      SomeBV state <- getSomeBVLocation v1
+      SomeBV key <- getSomeBVLocation v2
+      if | Just Refl <- testEquality (typeWidth state) (knownNat @128)
+         , Just Refl <- testEquality (typeWidth key) (knownNat @128) -> do
+             s <- eval =<< get state
+             k <- eval =<< get key
+             res <- evalArchFn (AESNI_AESDecLast s k)
+             state .= res
+         | otherwise -> fail "aesdeclast: State and key must be 128-bit"
   ]
   ++ def_cmov_list
   ++ def_jcc_list

--- a/x86/src/Data/Macaw/X86/Semantics.hs
+++ b/x86/src/Data/Macaw/X86/Semantics.hs
@@ -8,7 +8,6 @@ This module provides definitions for x86 instructions.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/x86/src/Data/Macaw/X86/Semantics.hs
+++ b/x86/src/Data/Macaw/X86/Semantics.hs
@@ -8,6 +8,7 @@ This module provides definitions for x86 instructions.
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/x86/src/Data/Macaw/X86/Semantics/AESNI.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AESNI.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE MultiWayIf, GADTs, RankNTypes, DataKinds, TypeApplications #-}
+
+module Data.Macaw.X86.Semantics.AESNI (all_instructions) where
+
+import qualified Flexdis86 as F
+
+import Data.Type.Equality
+
+import Data.Macaw.Types
+
+import Data.Macaw.X86.InstructionDef
+import Data.Macaw.X86.Getters
+import Data.Macaw.X86.Monad
+
+def_aesni
+  :: String
+  -> (forall f. (f (BVType 128)) -> (f (BVType 128)) -> X86PrimFn f (BVType 128))
+  -> InstructionDef
+def_aesni n op =
+  defBinary n $ \_ v1 v2 -> do
+    SomeBV state <- getSomeBVLocation v1
+    SomeBV key <- getSomeBVLocation v2
+    if | Just Refl <- testEquality (typeWidth state) (knownNat @128)
+       , Just Refl <- testEquality (typeWidth key) (knownNat @128) -> do
+           s <- eval =<< get state
+           k <- eval =<< get key
+           res <- evalArchFn $ op s k
+           state .= res
+       | otherwise -> fail $ n ++ ": State and key must be 128-bit"
+
+def_aeskeygenassist :: InstructionDef
+def_aeskeygenassist =
+  defTernary "aeskeygenassist" $ \_ vdest vsrc vimm -> do
+    SomeBV dest <- getSomeBVLocation vdest
+    SomeBV src <- getSomeBVLocation vsrc
+    if | Just Refl <- testEquality (typeWidth dest) n128
+       , Just Refl <- testEquality (typeWidth src) n128
+       , F.ByteImm k <- vimm -> do
+           s <- eval =<< get src
+           res <- evalArchFn (AESNI_AESKeyGenAssist s k)
+           dest .= res
+       | otherwise -> fail "aeskeygenassist: Invalid operands"
+
+def_pclmulqdq :: InstructionDef
+def_pclmulqdq =
+  defTernaryLVV "pclmulqdq" $ \dest src2 imm -> do
+    src1 <- get dest
+    if | Just Refl <- testEquality (typeWidth src1) n128
+       , Just Refl <- testEquality (typeWidth src2) n128
+       , Just Refl <- testEquality (typeWidth imm) n8 -> do
+           let (src1h, src1l) = bvSplit src1
+           let (src2h, src2l) = bvSplit src2
+           temp1 <- eval $ mux (bvBit imm $ bvLit (typeWidth imm) 0) src2h src2l
+           temp2 <- eval $ mux (bvBit imm $ bvLit (typeWidth imm) 4) src1h src1l
+           res <- evalArchFn (CLMul temp1 temp2)
+           dest .= res
+       | otherwise -> fail "pclmulqdq: Operands must be 128-bit"
+
+all_instructions :: [InstructionDef]
+all_instructions =
+  [ def_aesni "aesenc" AESNI_AESEnc
+  , def_aesni "aesenclast" AESNI_AESEncLast
+  , def_aesni "aesdec" AESNI_AESDec
+  , def_aesni "aesdeclast" AESNI_AESDecLast
+  , def_aeskeygenassist
+  , def_pclmulqdq
+  ]

--- a/x86/src/Data/Macaw/X86/Semantics/AVX.hs
+++ b/x86/src/Data/Macaw/X86/Semantics/AVX.hs
@@ -224,6 +224,8 @@ all_instructions =
 
   , avxPointwise2 "vpsubd" PtSub n32
 
+  , avxPointwise2 "vpcmpgtd" PtCmpGt n32
+
   , avxOp2 "vpand" VPAnd
   , avxOp2 "vpor" VPOr
   , avxOp2 "vpxor" VPXor

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -285,7 +285,7 @@ pureSem sym fn = do
               ys <- mapM (pure . ValBV n8 <=< projectLLVM_bv (symIface sym)) pys
               let res = DV.fromList $ V.toList $ shuffleB xs ys
               mapM (llvmPointer_bv (symIface sym) <=< evalE sym) res
-        _ -> error "PShufB"
+        _ -> error "PShufb is not implemented for 64-bit operands"
     M.MemCmp{}      -> error "MemCmp"
     M.RepnzScas{}   -> error "RepnzScas"
     M.MMXExtend {} -> error "MMXExtend"
@@ -478,7 +478,7 @@ pureSem sym fn = do
 
     M.AESNI_AESEnc x y -> pureSemAESNI sym fnAesEnc x y
     M.AESNI_AESEncLast x y -> pureSemAESNI sym fnAesEncLast x y
-    M.AESNI_AESDec x y -> pureSemAESNI sym fnAesDecLast x y
+    M.AESNI_AESDec x y -> pureSemAESNI sym fnAesDec x y
     M.AESNI_AESDecLast x y -> pureSemAESNI sym fnAesDecLast x y
     M.AESNI_AESKeyGenAssist x i ->
       do let f = fnAesKeyGenAssist (symFuns sym)

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -180,11 +180,19 @@ data Sym s = Sym { symIface :: s
 data SymFuns s = SymFuns
   { fnAesEnc ::
       SymFn s (EmptyCtx ::> BaseBVType 128 ::> BaseBVType 128) (BaseBVType 128)
-    -- ^ One round of AES
+    -- ^ One round of AES encryption
 
   , fnAesEncLast ::
       SymFn s (EmptyCtx ::> BaseBVType 128 ::> BaseBVType 128) (BaseBVType 128)
-    -- ^ Last round of AES
+    -- ^ Last round of AES encryption
+
+  , fnAesDec ::
+      SymFn s (EmptyCtx ::> BaseBVType 128 ::> BaseBVType 128) (BaseBVType 128)
+    -- ^ One round of AES decryption
+
+  , fnAesDecLast ::
+      SymFn s (EmptyCtx ::> BaseBVType 128 ::> BaseBVType 128) (BaseBVType 128)
+    -- ^ Last round of AES decryption
 
   , fnClMul ::
       SymFn s (EmptyCtx ::> BaseBVType 64 ::> BaseBVType 64) (BaseBVType 128)
@@ -197,6 +205,8 @@ newSymFuns :: forall sym. IsSymInterface sym => sym -> IO (SymFuns sym)
 newSymFuns s =
   do fnAesEnc     <- bin "aesEnc"
      fnAesEncLast <- bin "aesEncLast"
+     fnAesDec <- bin "aesDecLast"
+     fnAesDecLast <- bin "aesDecLast"
      fnClMul      <- bin "clMul"
      return SymFuns { .. }
 
@@ -428,6 +438,35 @@ pureSem sym fn = do
         V.zipWith (semPointwise op elSz) xs ys
 
     M.VExtractF128 {} -> error "VExtractF128"
+
+    M.AESNI_AESEnc x y ->
+      do let f = fnAesEnc (symFuns sym)
+             s = symIface sym
+         state <- toValBV s x
+         key <- toValBV s y
+         let ps = extend (extend empty state) key
+         llvmPointer_bv s =<< applySymFn s f ps
+    M.AESNI_AESEncLast x y ->
+      do let f = fnAesEncLast (symFuns sym)
+             s = symIface sym
+         state <- toValBV s x
+         key <- toValBV s y
+         let ps = extend (extend empty state) key
+         llvmPointer_bv s =<< applySymFn s f ps
+    M.AESNI_AESDec x y ->
+      do let f = fnAesDec (symFuns sym)
+             s = symIface sym
+         state <- toValBV s x
+         key <- toValBV s y
+         let ps = extend (extend empty state) key
+         llvmPointer_bv s =<< applySymFn s f ps
+    M.AESNI_AESDecLast x y ->
+      do let f = fnAesDecLast (symFuns sym)
+             s = symIface sym
+         state <- toValBV s x
+         key <- toValBV s y
+         let ps = extend (extend empty state) key
+         llvmPointer_bv s =<< applySymFn s f ps
 
 semPointwise :: (1 <= w) =>
   M.AVXPointWiseOp2 -> NatRepr w ->

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -475,6 +475,11 @@ semPointwise op w x y =
   case op of
     M.PtAdd -> app (BVAdd w x y)
     M.PtSub -> app (BVSub w x y)
+    M.PtCmpGt ->
+      let c = app (BVSle w y x)
+          t = app (BVLit w (BV.mkBV w (-1)))
+          e = app (BVLit w (BV.mkBV w 0))
+      in app (BVIte c w t e)
 
 -- | Assumes big-endian split
 -- See `vpalign` Intel instruction.

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -504,11 +504,11 @@ semPointwise op w x y =
   case op of
     M.PtAdd -> app (BVAdd w x y)
     M.PtSub -> app (BVSub w x y)
-    M.PtCmpGt ->
-      let c = app (BVSle w y x)
-          t = app (BVLit w (BV.mkBV w (-1)))
-          e = app (BVLit w (BV.mkBV w 0))
-      in app (BVIte c w t e)
+    M.PtCmpGt -> app $ BVIte
+      (app (BVSlt w y x))
+      w
+      (app (BVLit w (BV.mkBV w (-1))))
+      (app (BVLit w (BV.mkBV w 0)))
 
 -- | Assumes big-endian split
 -- See `vpalign` Intel instruction.


### PR DESCRIPTION
Namely:
- `aesenc`, `aesenclast`, `aesdec`, `aesdeclast`, `aeskeygenassist`
- `pclmulqdq`
- `psrl{w,d,q,dq}`
- `pshufb`
- `shufps`
- `vpcmpgtd`

The AESNI instructions and `pclmulqdq` work in the same way as the existing `vaesenc`/`vaesenclast`/`vpclmulqdq`, using uninterpreted functions.