### PR TITLE
ci: Have the CI build and test more things

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,18 @@ jobs:
       run: |
         cabal build --only-dependencies macaw-base
         cabal build crucible-llvm
-    - name: Cabal x86 tests
-      run: cabal test macaw-x86 macaw-x86-symbolic
-    - name: Cabal ASL tests
-      run: cabal test macaw-asl-tests
+    - name: macaw-x86 tests
+      run: |
+        cabal build pkg:macaw-x86 pkg:macaw-x86-symbolic
+        cabal test pkg:macaw-x86
+        cabal test pkg:macaw-x86-symbolic
+    - name: macaw-aarch32 tests
+      run: |
+        cabal build pkg:macaw-aarch32 pkg:macaw-aarch32-symbolic
+        cabal test pkg:macaw-aarch32
+    - name: macaw-ppc tests
+      run: |
+        cabal build pkg:macaw-ppc pkg:macaw-ppc-symbolic
+        cabal test pkg:macaw-ppc
     - name: compare-dwarfdump
       run: cabal build compare-dwarfdump

--- a/cabal.project.werror
+++ b/cabal.project.werror
@@ -15,8 +15,6 @@ package macaw-aarch32
 -- Macaw-aarch32-symbolic has warnings.
 package macaw-aarch32-symbolic
   ghc-options: -Wall
-package macaw-ppc
-  ghc-options: -Wall -Werror
 package macaw-ppc-symbolic
   ghc-options: -Wall -Werror
 package macaw-x86

--- a/cabal.project.werror
+++ b/cabal.project.werror
@@ -9,7 +9,7 @@ package macaw-symbolic
   ghc-options: -Wall -Werror
 -- Macaw-ppc has warnings.
 package macaw-ppc
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror
 package macaw-aarch32
   ghc-options: -Wall -Werror
 -- Macaw-aarch32-symbolic has warnings.


### PR DESCRIPTION
- Use an explicit package-level build step for each architecture, which will
build utility binaries and not just the tests/libraries
- Enable builds/tests for the PowerPC backend
- Build macaw-aarch32-symbolic

Fixes #175 