### PR TITLE
Export the DwarfExpr constructor

### DIFF
--- a/base/src/Data/Macaw/Dwarf.hs
+++ b/base/src/Data/Macaw/Dwarf.hs
@@ -63,6 +63,8 @@ module Data.Macaw.Dwarf
     -- * Name and Description
   , Name(..)
   , Description(..)
+    -- * Low-level access
+  , DwarfExpr(..)
     -- * Exports of "Data.Dwarf"
   , Dwarf.DieID
   , Dwarf.DW_OP(..)


### PR DESCRIPTION
This enables client code to decode the rest of the DWARF structure (which may
produce errors that we don't want to expose in the macaw-provided API).