### PR TITLE
aarch32: Change the register context

### DIFF
--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
@@ -138,7 +138,7 @@ type instance MSB.MacawArchStmtExtension SA.AArch32 =
 -- semantics
 --
 -- See Note [ARM Registers]
-type RegContext = PC.MapCtx ToMacawTypeWrapper LAG.GlobalsCtx
+type RegContext = PC.MapCtx ToMacawTypeWrapper (LAG.SimpleGlobalsCtx Ctx.<+> LAG.GPRCtx Ctx.<+> LAG.SIMDCtx)
 type instance MS.ArchRegContext SA.AArch32 = RegContext
 
 data ToMacawTypeWrapper :: PC.TyFun WT.BaseType MT.Type -> Type
@@ -146,7 +146,7 @@ type instance PC.Apply ToMacawTypeWrapper t = BaseToMacawType t
 
 aarch32RegAssignment :: Ctx.Assignment MAR.ARMReg RegContext
 aarch32RegAssignment =
-  I.runIdentity (PC.traverseMapCtx (Proxy @AsMacawReg) asARMReg LAG.allGlobalRefs)
+  I.runIdentity (PC.traverseMapCtx (Proxy @AsMacawReg) asARMReg (FC.fmapFC LAG.SimpleGlobalRef LAG.simpleGlobalRefs Ctx.<++> LAG.gprGlobalRefsSym Ctx.<++> LAG.simdGlobalRefsSym))
 
 data AsMacawReg :: PC.TyFun Symbol MT.Type -> Type
 type instance PC.Apply AsMacawReg s = BaseToMacawType (LAG.GlobalsType s)


### PR DESCRIPTION
The previous implementation used all of the registers defined in ASL translator.
It turns out that we don't actually use all of them in macaw; the significant
difference is that the `__memory` pseudo-location is used by asl-translator, but
not macaw (as macaw handles memory through implicit context).  This change
modifies the register assignment to include everything except memory (which
requires an update to the asl-translator submodule).