### PR TITLE
Remove isValidPtr checks in doPtrSub and doPtrEq.

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -120,6 +120,10 @@ module Data.Macaw.Symbolic
     -- $simulationExample
   , SymArchConstraints
   , macawExtensions
+  , PtrOp
+  , ptrOp
+  , isValidPtr
+  , mkUndefinedBool
   , MO.GlobalMap
   , MO.LookupFunctionHandle(..)
   , MO.MacawSimulatorState(..)


### PR DESCRIPTION
The operations are correct even when the pointers are not valid LLVM
pointers.