### PR TITLE
[symbolic] Rename EvalStmtFunc to MacawEvalStmtFunc

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -1126,7 +1126,7 @@ execMacawStmtExtension
   -- handles (which can also perform lazy CFG creation)
   -> MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
   -- ^ A function to make memory validity predicates (see 'MkGlobalPointerValidityAssertion' for details)
-  -> SB.EvalStmtFunc (MacawStmtExtension arch) (MacawSimulatorState sym) sym (MacawExt arch)
+  -> SB.MacawEvalStmtFunc (MacawStmtExtension arch) (MacawSimulatorState sym) sym (MacawExt arch)
 execMacawStmtExtension (SB.MacawArchEvalFn archStmtFn) mvar globs (MO.LookupFunctionHandle lookupH) toMemPred s0 st =
   case s0 of
     MacawReadMem addrWidth memRep ptr0 -> do

--- a/symbolic/src/Data/Macaw/Symbolic/Backend.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Backend.hs
@@ -15,7 +15,7 @@ module Data.Macaw.Symbolic.Backend (
   , CG.valueToCrucible
   , CG.evalArchStmt
   , MacawArchEvalFn(..)
-  , EvalStmtFunc
+  , MacawEvalStmtFunc
     -- ** Simulator Operations
   , MO.doPtrAdd
   , MO.doPtrSub
@@ -50,8 +50,13 @@ import qualified Data.Macaw.Symbolic.CrucGen as CG
 import qualified Data.Macaw.Symbolic.PersistentState as PS
 import qualified Data.Macaw.Symbolic.MemOps as MO
 
--- | A type for an evaluator of architecture-specific statements
-type EvalStmtFunc f p sym ext =
+-- | A type for an evaluator of architecture-specific statements.
+--  Note that this must map fairly directly to the C.EvalStmtFunc
+--  except that the `f` parameter here is used as a type family that
+--  is given a specific instance in the architecture-specific module,
+--  so this cannot be expressed directly as a `C.EvalStmtFunc`.
+
+type MacawEvalStmtFunc f p sym exts ext =
   forall rtp blocks r ctx tp'.
     f (C.RegEntry sym) tp'
     -> C.CrucibleState p sym ext rtp blocks r ctx
@@ -64,7 +69,12 @@ type EvalStmtFunc f p sym ext =
 -- values of this type, and instead should obtain values of this type from the
 -- 'withArchEval' function.
 newtype MacawArchEvalFn sym mem arch =
-  MacawArchEvalFn (C.GlobalVar mem -> MO.GlobalMap sym mem (M.ArchAddrWidth arch) -> EvalStmtFunc (CG.MacawArchStmtExtension arch) (MO.MacawSimulatorState sym) sym (CG.MacawExt arch))
+  MacawArchEvalFn (C.GlobalVar mem
+                  -> MO.GlobalMap sym mem (M.ArchAddrWidth arch)
+                  -> MacawEvalStmtFunc (CG.MacawArchStmtExtension arch)
+                                       (MO.MacawSimulatorState sym)
+                                       sym
+                                       (CG.MacawExt arch))
 
 -- $archBackend
 --

--- a/symbolic/src/Data/Macaw/Symbolic/Backend.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Backend.hs
@@ -56,7 +56,7 @@ import qualified Data.Macaw.Symbolic.MemOps as MO
 --  is given a specific instance in the architecture-specific module,
 --  so this cannot be expressed directly as a `C.EvalStmtFunc`.
 
-type MacawEvalStmtFunc f p sym exts ext =
+type MacawEvalStmtFunc f p sym ext =
   forall rtp blocks r ctx tp'.
     f (C.RegEntry sym) tp'
     -> C.CrucibleState p sym ext rtp blocks r ctx


### PR DESCRIPTION
There is already an `EvalStmtFunc` defined by Crucible, and while the two are related, the type signature is different.  Changing the name may cause some downstream impact, but there is no other change than the name (other than some formatting updates) and this helps disambiguate any references.