### PR TITLE
Only fix personality to (MS.MacawSimulatorState sym) where required.

### DIFF
--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
@@ -67,7 +67,7 @@ aarch32RegName r = WS.safeSymbol ("r!" ++ show (MC.prettyF r))
 
 aarch32MacawEvalFn :: (CB.IsSymInterface sym)
                    => AF.SymFuns sym
-                   -> MS.MacawArchEvalFn sym mem SA.AArch32
+                   -> MS.MacawArchEvalFn p sym mem SA.AArch32
 aarch32MacawEvalFn fs = MSB.MacawArchEvalFn $ \_ _ xt s ->
   case xt of
     AArch32PrimFn p -> AF.funcSemantics fs p s

--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Functions.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Functions.hs
@@ -57,7 +57,7 @@ newSymFuns _sym = do
   r <- IOR.newIORef Map.empty
   return SymFuns { symFuns = r }
 
-type S sym rtp bs r ctx = CS.CrucibleState (MS.MacawSimulatorState sym) sym (MS.MacawExt SA.AArch32) rtp bs r ctx
+type S p sym rtp bs r ctx = CS.CrucibleState p sym (MS.MacawExt SA.AArch32) rtp bs r ctx
 
 -- | Semantics for ARM-specific block terminators
 --
@@ -72,8 +72,8 @@ type S sym rtp bs r ctx = CS.CrucibleState (MS.MacawSimulatorState sym) sym (MS.
 termSemantics :: (CB.IsSymInterface sym)
               => SymFuns sym
               -> MAA.ARMTermStmt ids
-              -> S sym rtp bs r ctx
-              -> IO (CS.RegValue sym CT.UnitType, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (CS.RegValue sym CT.UnitType, S p sym rtp bs r ctx)
 termSemantics _sfns tstmt _st0 =
   case tstmt of
     MAA.ARMSyscall _payload ->
@@ -89,8 +89,8 @@ termSemantics _sfns tstmt _st0 =
 stmtSemantics :: (CB.IsSymInterface sym)
               => SymFuns sym
               -> MAA.ARMStmt (AA.AtomWrapper (CS.RegEntry sym))
-              -> S sym rtp bs r ctx
-              -> IO (CS.RegValue sym CT.UnitType, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (CS.RegValue sym CT.UnitType, S p sym rtp bs r ctx)
 stmtSemantics _sfns stmt _st0 =
   case stmt of
     MAA.UninterpretedA32Opcode opc _ops ->
@@ -101,8 +101,8 @@ stmtSemantics _sfns stmt _st0 =
 funcSemantics :: (CB.IsSymInterface sym, MS.ToCrucibleType mt ~ t)
               => SymFuns sym
               -> MAA.ARMPrimFn (AA.AtomWrapper (CS.RegEntry sym)) mt
-              -> S sym rtp bs r ctx
-              -> IO (CS.RegValue sym t, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (CS.RegValue sym t, S p sym rtp bs r ctx)
 funcSemantics sfns fn st0 =
   case fn of
     MAA.SDiv _rep lhs rhs -> withSym st0 $ \sym -> do
@@ -161,9 +161,9 @@ funcSemantics sfns fn st0 =
     MAA.FPRoundInt {} -> X.throwIO (MissingSemanticsForFunction "FPRoundInt")
 
 withSym :: (CB.IsSymInterface sym)
-        => S sym rtp bs r ctx
+        => S p sym rtp bs r ctx
         -> (sym -> IO a)
-        -> IO (a, S sym rtp bs r ctx)
+        -> IO (a, S p sym rtp bs r ctx)
 withSym s action = do
   let sym = s ^. CSET.stateSymInterface
   val <- action sym

--- a/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic.hs
+++ b/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic.hs
@@ -119,7 +119,7 @@ ppcMacawEvalFn :: ( C.IsSymInterface sym
                   , 1 <= SP.AddrWidth v
                   )
                => F.SymFuns sym
-               -> MS.MacawArchEvalFn sym mem (SP.AnyPPC v)
+               -> MS.MacawArchEvalFn p sym mem (SP.AnyPPC v)
 ppcMacawEvalFn fs = MSB.MacawArchEvalFn $ \_ _ xt s -> case xt of
   PPCPrimFn fn -> F.funcSemantics fs fn s
   PPCPrimStmt stmt -> F.stmtSemantics fs stmt s

--- a/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic/Functions.hs
+++ b/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic/Functions.hs
@@ -65,15 +65,15 @@ instance X.Exception SemanticsError
 termSemantics :: (C.IsSymInterface sym, 1 <= SP.AddrWidth v)
               => SymFuns sym
               -> MP.PPCTermStmt v ids
-              -> S v sym rtp bs r ctx
-              -> IO (C.RegValue sym C.UnitType, S v sym rtp bs r ctx)
+              -> S p v sym rtp bs r ctx
+              -> IO (C.RegValue sym C.UnitType, S p v sym rtp bs r ctx)
 termSemantics = error "PowerPC-specific terminator statement semantics not yet implemented"
 
 stmtSemantics :: (C.IsSymInterface sym, 1 <= SP.AddrWidth v)
               => SymFuns sym
               -> MP.PPCStmt v (A.AtomWrapper (C.RegEntry sym))
-              -> S v sym rtp bs r ctx
-              -> IO (C.RegValue sym C.UnitType, S v sym rtp bs r ctx)
+              -> S p v sym rtp bs r ctx
+              -> IO (C.RegValue sym C.UnitType, S p v sym rtp bs r ctx)
 stmtSemantics _sf stmt s =
   case stmt of
     MP.Attn -> do
@@ -114,8 +114,8 @@ stmtSemantics _sf stmt s =
 funcSemantics :: (C.IsSymInterface sym, MS.ToCrucibleType mt ~ t, 1 <= SP.AddrWidth v)
               => SymFuns sym
               -> MP.PPCPrimFn v (A.AtomWrapper (C.RegEntry sym)) mt
-              -> S v sym rtp bs r ctx
-              -> IO (C.RegValue sym t, S v sym rtp bs r ctx)
+              -> S p v sym rtp bs r ctx
+              -> IO (C.RegValue sym t, S p v sym rtp bs r ctx)
 funcSemantics sf pf s =
   case pf of
     MP.UDiv _rep lhs rhs -> do
@@ -359,9 +359,9 @@ toValFloat _ (A.AtomWrapper x) = C.regValue x
 
 withSym
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> (sym -> IO a)
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSym s action = do
   let sym = s ^. C.stateSymInterface
   val <- action sym
@@ -369,26 +369,26 @@ withSym s action = do
 
 withSymBVUnOp
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> A.AtomWrapper (C.RegEntry sym) (MT.BVType w)
   -> (sym -> C.RegValue sym (C.BVType w) -> IO a)
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSymBVUnOp s x action = withSym s $ \sym -> action sym =<< toValBV sym x
 
 withSymFPUnOp
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> A.AtomWrapper (C.RegEntry sym) (MT.FloatType fi)
   -> (  sym
      -> C.RegValue sym (MS.ToCrucibleType (MT.FloatType fi))
      -> IO a
      )
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSymFPUnOp s x action = withSym s $ \sym -> action sym $ toValFloat sym x
 
 withSymFPBinOp
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> A.AtomWrapper (C.RegEntry sym) (MT.FloatType fi)
   -> A.AtomWrapper (C.RegEntry sym) (MT.FloatType fi)
   -> (  sym
@@ -396,7 +396,7 @@ withSymFPBinOp
      -> C.RegValue sym (MS.ToCrucibleType (MT.FloatType fi))
      -> IO a
      )
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSymFPBinOp s x y action = withSym s $ \sym -> do
   let x' = toValFloat sym x
   let y' = toValFloat sym y
@@ -412,4 +412,4 @@ withRounding sym r action = do
   r' <- toValBV sym r
   U.withRounding sym r' action
 
-type S v sym rtp bs r ctx = C.CrucibleState (MS.MacawSimulatorState sym) sym (MS.MacawExt (SP.AnyPPC v)) rtp bs r ctx
+type S p v sym rtp bs r ctx = C.CrucibleState p sym (MS.MacawExt (SP.AnyPPC v)) rtp bs r ctx

--- a/symbolic/src/Data/Macaw/Symbolic/Backend.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Backend.hs
@@ -68,11 +68,11 @@ type MacawEvalStmtFunc f p sym ext =
 -- architecture-specific backends - client code should not need to construct
 -- values of this type, and instead should obtain values of this type from the
 -- 'withArchEval' function.
-newtype MacawArchEvalFn sym mem arch =
+newtype MacawArchEvalFn p sym mem arch =
   MacawArchEvalFn (C.GlobalVar mem
                   -> MO.GlobalMap sym mem (M.ArchAddrWidth arch)
                   -> MacawEvalStmtFunc (CG.MacawArchStmtExtension arch)
-                                       (MO.MacawSimulatorState sym)
+                                       p
                                        sym
                                        (CG.MacawExt arch))
 

--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -331,11 +331,11 @@ type Regs sym arch = Ctx.Assignment (C.RegValue' sym)
 -- constructing the CFG of the callee on the fly) and register them with the
 -- simulator.
 data LookupFunctionHandle sym arch = LookupFunctionHandle
-     (forall rtp blocks r ctx
-   . CrucibleState (MacawSimulatorState sym) sym (MacawExt arch) rtp blocks r ctx
+     (forall rtp blocks r ctx p
+   . CrucibleState p sym (MacawExt arch) rtp blocks r ctx
   -> MemImpl sym
   -> Ctx.Assignment (C.RegValue' sym) (MacawCrucibleRegTypes arch)
-  -> IO (C.FnHandle (Ctx.EmptyCtx Ctx.::> ArchRegStruct arch) (ArchRegStruct arch), CrucibleState (MacawSimulatorState sym) sym (MacawExt arch) rtp blocks r ctx))
+  -> IO (C.FnHandle (Ctx.EmptyCtx Ctx.::> ArchRegStruct arch) (ArchRegStruct arch), CrucibleState p sym (MacawExt arch) rtp blocks r ctx))
 
 --------------------------------------------------------------------------------
 doLookupFunctionHandle :: (IsSymInterface sym)

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -83,15 +83,15 @@ import qualified Data.Macaw.X86.ArchTypes as M
 import           Prelude
 
 
-type S sym rtp bs r ctx =
-  CrucibleState (MacawSimulatorState sym) sym (MacawExt M.X86_64) rtp bs r ctx
+type S p sym rtp bs r ctx =
+  CrucibleState p sym (MacawExt M.X86_64) rtp bs r ctx
 
 funcSemantics
   :: (IsSymInterface sym, ToCrucibleType mt ~ t)
   => SymFuns sym
   -> M.X86PrimFn (AtomWrapper (RegEntry sym)) mt
-  -> S sym rtp bs r ctx
-  -> IO (RegValue sym t, S sym rtp bs r ctx)
+  -> S p sym rtp bs r ctx
+  -> IO (RegValue sym t, S p sym rtp bs r ctx)
 funcSemantics fs x s = do let sym = Sym { symIface = s^.stateSymInterface
                                         , symTys   = s^.stateIntrinsicTypes
                                         , symFuns  = fs
@@ -101,12 +101,12 @@ funcSemantics fs x s = do let sym = Sym { symIface = s^.stateSymInterface
 
 withConcreteCountAndDir
   :: (IsSymInterface sym, 1 <= w)
-  => S sym rtp bs r ctx
+  => S p sym rtp bs r ctx
   -> M.RepValSize w
   -> (AtomWrapper (RegEntry sym) (M.BVType 64))
   -> (AtomWrapper (RegEntry sym) M.BoolType)
-  -> (S sym rtp bs r ctx -> (SymBV sym 64) -> IO (S sym rtp bs r ctx))
-  -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
+  -> (S p sym rtp bs r ctx -> (SymBV sym 64) -> IO (S p sym rtp bs r ctx))
+  -> IO (RegValue sym UnitType, S p sym rtp bs r ctx)
 withConcreteCountAndDir state val_size wrapped_count _wrapped_dir func = do
   let sym = state^.stateSymInterface
   let val_byte_size :: Integer
@@ -127,8 +127,8 @@ stmtSemantics
   -> C.GlobalVar Mem
   -> GlobalMap sym Mem (M.ArchAddrWidth M.X86_64)
   -> M.X86Stmt (AtomWrapper (RegEntry sym))
-  -> S sym rtp bs r ctx
-  -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
+  -> S p sym rtp bs r ctx
+  -> IO (RegValue sym UnitType, S p sym rtp bs r ctx)
 stmtSemantics _sym_funs global_var_mem globals stmt state = do
   let sym = state^.stateSymInterface
   case stmt of
@@ -167,8 +167,8 @@ stmtSemantics _sym_funs global_var_mem globals stmt state = do
 termSemantics :: (IsSymInterface sym)
               => SymFuns sym
               -> M.X86TermStmt ids
-              -> S sym rtp bs r ctx
-              -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (RegValue sym UnitType, S p sym rtp bs r ctx)
 termSemantics _fs x _s = error ("Symbolic execution semantics for x86 terminators are not implemented yet: " <>
                                (show $ MC.prettyF x))
 

--- a/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
@@ -318,7 +318,7 @@ x86_64MacawSymbolicFns =
 x86_64MacawEvalFn
   :: (C.IsSymInterface sym, MM.HasLLVMAnn sym)
   => SymFuns sym
-  -> MacawArchEvalFn sym MM.Mem M.X86_64
+  -> MacawArchEvalFn p sym MM.Mem M.X86_64
 x86_64MacawEvalFn fs =
   MacawArchEvalFn $ \global_var_mem globals ext_stmt crux_state ->
     case ext_stmt of


### PR DESCRIPTION
In preparation for Polyglot support, this changes various locations that had unnecessarily hard-coded the personality to `MS.MacawSimulatorState sym` back to a generic  `p` type parameter.  The fixed personality was left in the few locations where it needed to be explicit.