### PR TITLE
doc: fix MemCmp docs w.r.t. semantics of return value

### DIFF
--- a/x86/src/Data/Macaw/X86/ArchTypes.hs
+++ b/x86/src/Data/Macaw/X86/ArchTypes.hs
@@ -370,7 +370,8 @@ data X86PrimFn f tp where
   GetSegmentSelector :: !F.Segment
                      -> X86PrimFn f (BVType 16)
 
-  -- | Compares two memory regions and return the number of bytes that were the same.
+  -- | Compares two memory regions and returns the number of compared values that
+  -- were the same. E.g., used to implement instructions of the form 'repz cmps ...'.
   --
   -- In an expression @MemCmp bpv nv p1 p2 dir@:
   --


### PR DESCRIPTION
`MemCmp` is essentially a primitive x86 "pseudo-instruction" used to represent computations such as `repz cmps ...` (see it's only usage in the x86 semantics [here](https://github.com/GaloisInc/macaw/blob/9069e114fd309276902dba93eef989c1ab95005a/x86/src/Data/Macaw/X86/Semantics.hs#L1448)).

`MemCmp bpv nv p1 p2 dir` is incorrectly documented to `return the number of bytes that were the same` when the return value is actually the number of `compared values` that were the same, i.e., it's only the number of bytes when`bpv == 1` (i.e., the number of bytes per value is `1`).

Evidence: the returned value is actually the number of _compared values_ of size `bpv` that were the same (as can be seen [here](https://github.com/GaloisInc/macaw/blob/9069e114fd309276902dba93eef989c1ab95005a/x86/src/Data/Macaw/X86/Semantics.hs#L1476) in the x86 semantics in Macaw). There is no entry for precisely this instruction in the Intel® 64 and IA-32 Architectures Software Developer’s Manual since it is not actually an x86 instruction, but the return value of `MemCmp` should correspond to the number of visited values (i.e., the value of the count register after iteration stops) minus 1 if the ZF flag status indicates that the last seen values did not match (which is precisely what the Macaw x86 semantics do). Additionally, note that on page `4-561` of the Intel manual, the count register (i.e., the source from which the return value is derived) is always decremented by 1 per iteration regardless of the bytes per value.