### PR TITLE
Fix the default ppc32 ABI

### DIFF
--- a/macaw-ppc/src/Data/Macaw/PPC.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC.hs
@@ -96,7 +96,7 @@ ppc64_linux_info binData =
                       , MI.archAddrWidth = MM.Addr64
                       , MI.archEndianness = MM.BigEndian
                       , MI.disassembleFn = disassembleFn proxy PPC64.execInstruction
-                      , MI.mkInitialAbsState = mkInitialAbsState proxy binData
+                      , MI.mkInitialAbsState = mkInitialAbsState proxy (Just toc)
                       , MI.absEvalArchFn = absEvalArchFn proxy
                       , MI.absEvalArchStmt = absEvalArchStmt proxy
                       , MI.identifyCall = identifyCall proxy
@@ -113,17 +113,15 @@ ppc64_linux_info binData =
                       }
   where
     proxy = Proxy @PPC.V64
+    toc = BLP.getTOC binData
 
-ppc32_linux_info :: ( BLP.HasTOC PPC32.PPC binFmt
-                    ) =>
-                    BL.LoadedBinary PPC32.PPC binFmt
-                 -> MI.ArchitectureInfo PPC32.PPC
-ppc32_linux_info binData =
+ppc32_linux_info :: MI.ArchitectureInfo PPC32.PPC
+ppc32_linux_info =
   MI.ArchitectureInfo { MI.withArchConstraints = \x -> x
                       , MI.archAddrWidth = MM.Addr32
                       , MI.archEndianness = MM.BigEndian
                       , MI.disassembleFn = disassembleFn proxy PPC32.execInstruction
-                      , MI.mkInitialAbsState = mkInitialAbsState proxy binData
+                      , MI.mkInitialAbsState = mkInitialAbsState proxy Nothing
                       , MI.absEvalArchFn = absEvalArchFn proxy
                       , MI.absEvalArchStmt = absEvalArchStmt proxy
                       , MI.identifyCall = identifyCall proxy

--- a/refinement/tools/Initialization.hs
+++ b/refinement/tools/Initialization.hs
@@ -71,7 +71,7 @@ withElf opts k = do
           withLoadedBinary k MX86.x86_64_linux_info bin
         (EE.ELFCLASS32, EE.EM_PPC) -> do
           bin <- MBL.loadBinary @PPC32.PPC ML.defaultLoadOptions elf
-          let archInfo = MP.ppc32_linux_info bin
+          let archInfo = MP.ppc32_linux_info
           withLoadedBinary k archInfo bin
         (_,m) -> X.throwM (UnsupportedArchitecture m)
     Left (_, s) -> do


### PR DESCRIPTION
None of the common default ppc32 ABIs use a Table of Contents (TOC), so default
our code to not assume it either. This has accompanying changes in
macaw-loader-ppc, which also made incorrect assumptions about ppc32.

Note that we may eventually need to support rarely-used ABIs that do use a
TOC (or similar dedicated registers, e.g., the Small Data Area mode). When we
do, we will probably want that to be a data-oriented decision rather than a
type-level one, as each architecture supports multiple ABIs. We may also need to
modify ppc64 to support ABIs without TOCs, but we'll do it when we need to.