### PR TITLE
Expose block classification in the ArchitectureInfo

### DIFF
--- a/base/macaw-base.cabal
+++ b/base/macaw-base.cabal
@@ -66,6 +66,10 @@ library
     Data.Macaw.DebugLogging
     Data.Macaw.Discovery
     Data.Macaw.Discovery.AbsEval
+    Data.Macaw.Discovery.Classifier
+    Data.Macaw.Discovery.Classifier.JumpTable
+    Data.Macaw.Discovery.Classifier.PLT
+    Data.Macaw.Discovery.ParsedContents
     Data.Macaw.Discovery.State
     Data.Macaw.Dwarf
     Data.Macaw.Fold

--- a/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
+++ b/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
@@ -32,6 +32,8 @@ module Data.Macaw.AbsDomain.JumpBounds
   , BranchBounds(..)
   , postBranchBounds
   , unsignedUpperBound
+  -- * Jump Targets
+  , IntraJumpTarget
   ) where
 
 import           Control.Monad.Reader
@@ -48,6 +50,7 @@ import           Data.Parameterized.Pair
 import           Numeric.Natural
 import           Prettyprinter
 
+import           Data.Macaw.AbsDomain.AbsState ( AbsBlockState )
 import           Data.Macaw.AbsDomain.CallParams
 import           Data.Macaw.AbsDomain.StackAnalysis
 import           Data.Macaw.CFG.App
@@ -846,3 +849,14 @@ postCallBounds params cns regs =
                      , initRngPredMap = locMapEmpty
                      , initAddrPredMap = Map.empty
                      }
+
+-- | This type is used to represent the location to return to *within a
+-- function* after executing an architecture-specific terminator instruction.
+--
+--  * The 'MemSegmentOff' is the address to jump to next (within the function)
+--  * The 'AbsBlockState' is the abstract state to use at the start of the block returned to (reflecting any changes made by the architecture-specific terminator)
+--  * The 'Jmp.InitJumpBounds' is a collection of relations between values in registers and on the stack that should hold (see 'Jmp.postCallBounds' for to construct this in the common case)
+--
+-- Note: This is defined here (despite not being used here) to avoid import cycles elsewhere
+type IntraJumpTarget arch =
+  (MemSegmentOff (ArchAddrWidth arch), AbsBlockState (ArchReg arch), InitJumpBounds arch)

--- a/base/src/Data/Macaw/Architecture/Info.hs
+++ b/base/src/Data/Macaw/Architecture/Info.hs
@@ -1,23 +1,38 @@
 {-|
 This defines the architecture-specific information needed for code discovery.
 -}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 module Data.Macaw.Architecture.Info
   ( ArchitectureInfo(..)
   , postCallAbsState
-  , ArchBlockPrecond
   , DisassembleFn
-  , IntraJumpTarget
+   -- * Block classification
+  , BlockClassifier
+  , BlockClassifierM
+  , runBlockClassifier
+  , BlockClassifierContext(..)
+  , Classifier(..)
+  , classifierName
+  , liftClassifier
+  , ParseContext(..)
+  , NoReturnFunStatus(..)
     -- * Unclassified blocks
   , module Data.Macaw.CFG.Block
   , rewriteBlock
   ) where
 
-import           Control.Monad.ST
-import qualified Data.Kind as K
+import           Control.Applicative ( Alternative(..), liftA )
+import           Control.Monad ( ap )
+import qualified Control.Monad.Fail as MF
+import qualified Control.Monad.Reader as CMR
+import qualified Control.Monad.Trans as CMT
+import           Control.Monad.ST ( ST )
+import           Data.Map ( Map )
 import           Data.Parameterized.Nonce
 import           Data.Parameterized.TraversableF
 import           Data.Sequence (Seq)
@@ -28,23 +43,172 @@ import           Data.Macaw.CFG.Block
 import           Data.Macaw.CFG.Core
 import           Data.Macaw.CFG.DemandSet
 import           Data.Macaw.CFG.Rewriter
+import qualified Data.Macaw.Discovery.ParsedContents as Parsed
 import           Data.Macaw.Memory
+
+
+------------------------------------------------------------------------
+-- NoReturnFunStatus
+
+-- | Flags whether a function is labeled no return or not.
+data NoReturnFunStatus
+   = NoReturnFun
+     -- ^ Function labeled no return
+   | MayReturnFun
+     -- ^ Function may retun
+
+type ClassificationError = String
+
+-- | The result of block classification, which collects information about all of
+-- the match failures to help diagnose shortcomings in the analysis
+data Classifier o = ClassifyFailed    [ClassificationError]
+                  | ClassifySucceeded [ClassificationError] o
+
+-- | In the given context, set the name of the current classifier
+--
+-- This is used to improve the labels for each classifier failure
+classifierName :: String -> BlockClassifierM arch ids a -> BlockClassifierM arch ids a
+classifierName nm (BlockClassifier (CMR.ReaderT m)) = BlockClassifier $ CMR.ReaderT $ \i ->
+  case m i of
+    ClassifyFailed [] -> ClassifyFailed [nm ++ " classification failed."]
+    ClassifyFailed l  -> ClassifyFailed (fmap ((nm ++ ": ") ++)  l)
+    ClassifySucceeded l a -> ClassifySucceeded (fmap ((nm ++ ": ") ++)  l) a
+
+classifyFail :: Classifier a
+classifyFail = ClassifyFailed []
+
+classifySuccess :: a -> Classifier a
+classifySuccess = \x -> ClassifySucceeded [] x
+
+classifyBind :: Classifier a -> (a -> Classifier b) -> Classifier b
+classifyBind m f =
+  case m of
+    ClassifyFailed e -> ClassifyFailed e
+    ClassifySucceeded [] a -> f a
+    ClassifySucceeded l a ->
+      case f a of
+        ClassifyFailed    e   -> ClassifyFailed    (l++e)
+        ClassifySucceeded e b -> ClassifySucceeded (l++e) b
+
+classifyAppend :: Classifier a -> Classifier a -> Classifier a
+classifyAppend m n =
+  case m of
+    ClassifySucceeded e a -> ClassifySucceeded e a
+    ClassifyFailed [] -> n
+    ClassifyFailed e ->
+      case n of
+        ClassifySucceeded f a -> ClassifySucceeded (e++f) a
+        ClassifyFailed f      -> ClassifyFailed    (e++f)
+
+instance Alternative Classifier where
+  empty = classifyFail
+  (<|>) = classifyAppend
+
+instance Functor Classifier where
+  fmap = liftA
+
+instance Applicative Classifier where
+  pure = classifySuccess
+  (<*>) = ap
+
+instance Monad Classifier where
+  (>>=) = classifyBind
+#if !(MIN_VERSION_base(4,13,0))
+  fail = MF.fail
+#endif
+
+instance MF.MonadFail Classifier where
+  fail = \m -> ClassifyFailed [m]
+
+------------------------------------------------------------------------
+-- ParseContext
+
+-- | Information needed to parse the processor state
+data ParseContext arch ids =
+  ParseContext { pctxMemory         :: !(Memory (ArchAddrWidth arch))
+               , pctxArchInfo       :: !(ArchitectureInfo arch)
+               , pctxKnownFnEntries :: !(Map (ArchSegmentOff arch) NoReturnFunStatus)
+                 -- ^ Entry addresses for known functions (e.g. from
+                 -- symbol information)
+                 --
+                 -- The discovery process will not create
+                 -- intra-procedural jumps to the entry points of new
+                 -- functions.
+               , pctxFunAddr        :: !(ArchSegmentOff arch)
+                 -- ^ Address of function containing this block.
+               , pctxAddr           :: !(ArchSegmentOff arch)
+                 -- ^ Address of the current block
+               , pctxExtResolution :: [(ArchSegmentOff arch, [ArchSegmentOff arch])]
+                 -- ^ Externally-provided resolutions for classification
+                 -- failures, which are used in parseFetchAndExecute
+               }
+
+{-| The fields of the 'BlockClassifierContext' are:
+
+  [@ParseContext ...@]: The context for the parse
+
+  [@RegState ...@]: Initial register values
+
+  [@Seq (Stmt ...)@]: The statements in the block
+
+  [@AbsProcessorState ...@]: Abstract state of registers prior to
+                             terminator statement being executed.
+
+  [@Jmp.IntraJumpBounds ...@]: Bounds prior to terminator statement
+                               being executed.
+
+  [@ArchSegmentOff arch@]: Address of all segments written to memory
+
+  [@RegState ...@]: Final register values
+-}
+data BlockClassifierContext arch ids = BlockClassifierContext
+  { classifierParseContext  :: !(ParseContext arch ids)
+  -- ^ Information needed to construct abstract processor states
+  , classifierInitRegState  :: !(RegState (ArchReg arch) (Value arch ids))
+  -- ^ The (concrete) register state at the beginning of the block
+  , classifierStmts         :: !(Seq (Stmt arch ids))
+  -- ^ The statements of the block (without the terminator)
+  , classifierBlockSize     :: !Int
+    -- ^ Size of block being classified.
+  , classifierAbsState      :: !(AbsProcessorState (ArchReg arch) ids)
+  -- ^ The abstract processor state before the terminator is executed
+  , classifierJumpBounds    :: !(Jmp.IntraJumpBounds arch ids)
+  -- ^ The relational abstract processor state before the terminator is executed
+  , classifierWrittenAddrs  :: !([ArchSegmentOff arch])
+  -- ^ The addresses of observed memory writes in the block
+  , classifierFinalRegState :: !(RegState (ArchReg arch) (Value arch ids))
+  -- ^ The final (concrete) register state before the terminator is executed
+  }
+
+type BlockClassifier arch ids = BlockClassifierM arch ids (Parsed.ParsedContents arch ids)
+
+-- | The underlying monad for the 'BlockClassifier', which handles collecting
+-- matching errors
+newtype BlockClassifierM arch ids a =
+  BlockClassifier { unBlockClassifier :: CMR.ReaderT (BlockClassifierContext arch ids)
+                                                     Classifier
+                                                     a
+                  }
+  deriving ( Functor
+           , Applicative
+           , Alternative
+           , Monad
+           , MF.MonadFail
+           , CMR.MonadReader (BlockClassifierContext arch ids)
+           )
+
+-- | Run a classifier in a given block context
+runBlockClassifier
+  :: BlockClassifier arch ids
+  -> BlockClassifierContext arch ids
+  -> Classifier (Parsed.ParsedContents arch ids)
+runBlockClassifier cl = CMR.runReaderT (unBlockClassifier cl)
+
+liftClassifier :: Classifier a -> BlockClassifierM arch ids a
+liftClassifier c = BlockClassifier (CMT.lift c)
 
 ------------------------------------------------------------------------
 -- ArchitectureInfo
-
--- | This family maps architecture parameters to information needed to
--- successfully translate machine code into Macaw CFGs.
---
--- This is currently used for registers values that are required to be
--- known constants at translation time.  For example, on X86_64, due to
--- aliasing between the FPU and MMX registers, we require that the
--- floating point stack value is known at translation time so that
--- we do not need to check which register is modified when pushing or
--- poping from the x86 stack.
---
--- If no preconditions are needed, this can just be set to the unit type.
-type family ArchBlockPrecond (arch :: K.Type) :: K.Type
 
 -- | Function for disassembling a range of code (usually a function in
 -- the target code image) into blocks.
@@ -65,16 +229,6 @@ type DisassembleFn arch
    -> Int
       -- ^ Maximum offset for this to read from.
    -> ST s (Block arch ids, Int)
-
--- | This type is used to represent the location to return to *within a
--- function* after executing an architecture-specific terminator instruction.
---
---  * The 'MemSegmentOff' is the address to jump to next (within the function)
---  * The 'AbsBlockState' is the abstract state to use at the start of the block returned to (reflecting any changes made by the architecture-specific terminator)
---  * The 'Jmp.InitJumpBounds' is a collection of relations between values in registers and on the stack that should hold (see 'Jmp.postCallBounds' for to construct this in the common case)
-type IntraJumpTarget arch =
-  (MemSegmentOff (ArchAddrWidth arch), AbsBlockState (ArchReg arch), Jmp.InitJumpBounds arch)
-
 
 -- | This records architecture specific functions for analysis.
 data ArchitectureInfo arch
@@ -178,7 +332,7 @@ data ArchitectureInfo arch
                                      -> RegState (ArchReg arch) (Value arch ids)
                                         -- The architecture-specific statement
                                      -> ArchTermStmt arch ids
-                                     -> Maybe (IntraJumpTarget arch))
+                                     -> Maybe (Jmp.IntraJumpTarget arch))
        -- ^ This takes an abstract state from before executing an abs
        -- state, and an architecture-specific terminal statement.
        --
@@ -190,6 +344,9 @@ data ArchitectureInfo arch
        -- Note that per their documentation, architecture specific
        -- statements may return to at most one location within a
        -- function.
+     , archClassifier :: !(forall ids . BlockClassifier arch ids)
+     -- ^ The block classifier to use for this architecture, which can be
+     -- customized
      }
 
 postCallAbsState :: ArchitectureInfo arch

--- a/base/src/Data/Macaw/CFG.hs
+++ b/base/src/Data/Macaw/CFG.hs
@@ -9,10 +9,8 @@ module Data.Macaw.CFG
   , module Data.Macaw.CFG.App
   , module Data.Macaw.Memory
   , Data.Macaw.Types.FloatInfoRepr(..)
-  , Data.Macaw.Architecture.Info.ArchBlockPrecond
   ) where
 
-import qualified Data.Macaw.Architecture.Info
 import           Data.Macaw.CFG.App
 import           Data.Macaw.CFG.Core
 import           Data.Macaw.Memory

--- a/base/src/Data/Macaw/CFG/Core.hs
+++ b/base/src/Data/Macaw/CFG/Core.hs
@@ -87,6 +87,7 @@ module Data.Macaw.CFG.Core
     -- ** Synonyms
   , ArchAddrValue
   , ArchSegmentOff
+  , ArchBlockPrecond
   , Data.Parameterized.TraversableFC.FoldableFC(..)
   , module Data.Macaw.CFG.AssignRhs
   , module Data.Macaw.Utils.Pretty
@@ -120,6 +121,18 @@ import           Data.Macaw.Memory
 import           Data.Macaw.Types
 import           Data.Macaw.Utils.Pretty
 
+-- | This family maps architecture parameters to information needed to
+-- successfully translate machine code into Macaw CFGs.
+--
+-- This is currently used for registers values that are required to be
+-- known constants at translation time.  For example, on X86_64, due to
+-- aliasing between the FPU and MMX registers, we require that the
+-- floating point stack value is known at translation time so that
+-- we do not need to check which register is modified when pushing or
+-- poping from the x86 stack.
+--
+-- If no preconditions are needed, this can just be set to the unit type.
+type family ArchBlockPrecond (arch :: Kind.Type) :: Kind.Type
 
 -- | A pair containing a segment and valid offset within the segment.
 type ArchSegmentOff arch = MemSegmentOff (ArchAddrWidth arch)

--- a/base/src/Data/Macaw/Discovery.hs
+++ b/base/src/Data/Macaw/Discovery.hs
@@ -63,52 +63,48 @@ module Data.Macaw.Discovery
        , State.JumpTableLayout
        , State.jtlBackingAddr
        , State.jtlBackingSize
+       -- * Block classifiers
+       , BlockClassifier
+       , defaultClassifier
+       , branchClassifier
+       , callClassifier
+       , returnClassifier
+       , directJumpClassifier
+       , noreturnCallClassifier
+       , tailCallClassifier
+       , pltStubClassifier
+       , jumpTableClassifier
          -- * Simplification
        , eliminateDeadStmts
          -- * Re-exports
        , ArchAddrWidth
        ) where
 
-import           Control.Applicative ( Alternative((<|>), empty), liftA )
-import           Control.Lens
-import qualified Control.Monad.Fail as Fail
-import           Control.Monad.Reader
+import           Control.Applicative ( Alternative((<|>)) )
+import           Control.Lens ( Lens', (&), (^.), (%~), (.~), (%=), use, lens, _Just, at )
+import           Control.Monad ( when )
 import qualified Control.Monad.ST.Lazy as STL
 import qualified Control.Monad.ST.Strict as STS
-import           Control.Monad.State.Strict
-import qualified Data.ByteString as BS
+import qualified Control.Monad.State.Strict as CMS
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Foldable
-import           Data.Int
+import qualified Data.Foldable as F
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe
-import           Data.Monoid
-import           Data.Parameterized.Classes
-import qualified Data.Parameterized.Map as MapF
-import           Data.Parameterized.NatRepr
-import           Data.Parameterized.Nonce
-import           Data.Parameterized.Some
-import           Data.Parameterized.TraversableF
-import           Data.Sequence (Seq)
+import           Data.Maybe ( fromMaybe, maybeToList )
+import qualified Data.Parameterized.Classes as PC
+import qualified Data.Parameterized.Nonce as PN
+import           Data.Parameterized.Some ( Some(..) )
+import qualified Data.Parameterized.TraversableF as TF
 import qualified Data.Sequence as Seq
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
-import qualified Data.Vector as V
-import           Data.Word
-import           Numeric
-import           Numeric.Natural
-import           Prettyprinter (pretty)
-import           System.IO
-import           Text.Printf (printf)
+import qualified System.IO as IO
 
 #define USE_REWRITER
 
 import           Data.Macaw.AbsDomain.AbsState
 import qualified Data.Macaw.AbsDomain.JumpBounds as Jmp
-import           Data.Macaw.AbsDomain.Refine
-import qualified Data.Macaw.AbsDomain.StridedInterval as SI
 import           Data.Macaw.Architecture.Info
 import           Data.Macaw.CFG
 import           Data.Macaw.CFG.DemandSet
@@ -117,32 +113,15 @@ import           Data.Macaw.CFG.Rewriter
 #endif
 import           Data.Macaw.DebugLogging
 import           Data.Macaw.Discovery.AbsEval
+import           Data.Macaw.Discovery.Classifier
+import           Data.Macaw.Discovery.Classifier.JumpTable ( jumpTableClassifier )
+import           Data.Macaw.Discovery.Classifier.PLT ( pltStubClassifier )
+import           Data.Macaw.Discovery.ParsedContents
 import           Data.Macaw.Discovery.State as State
 import qualified Data.Macaw.Memory.Permissions as Perm
 import           Data.Macaw.Types
 import           Data.Macaw.Utils.IncComp
 
-------------------------------------------------------------------------
--- Utilities
-
-isExecutableSegOff :: MemSegmentOff w -> Bool
-isExecutableSegOff sa =
-  segmentFlags (segoffSegment sa) `Perm.hasPerm` Perm.execute
-
--- | Get code pointers out of a abstract value.
-identifyConcreteAddresses :: MemWidth w
-                          => Memory w
-                          -> AbsValue w (BVType w)
-                          -> [MemSegmentOff w]
-identifyConcreteAddresses mem (FinSet s) =
-  let ins o r =
-        case resolveAbsoluteAddr mem (fromInteger o) of
-          Just a | isExecutableSegOff a -> a : r
-          _ -> r
-   in foldr ins [] s
-identifyConcreteAddresses _ (CodePointers s _) = filter isExecutableSegOff $ Set.toList s
-identifyConcreteAddresses _mem StridedInterval{} = []
-identifyConcreteAddresses _mem _ = []
 
 {-
 -- | Return true if this address was added because of the contents of a global address
@@ -175,11 +154,11 @@ addTermDemands :: TermStmt arch ids -> DemandComp arch ids ()
 addTermDemands t =
   case t of
     FetchAndExecute regs -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     TranslateError regs _ -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ArchTermStmt _ regs -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
 
 -- | Add any assignments needed to evaluate statements with side
 -- effects and terminal statement to demand set.
@@ -211,23 +190,23 @@ addParsedBlockDemands b = do
   mapM_ addStmtDemands (pblockStmts b)
   case pblockTermStmt b of
     ParsedCall regs _ -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     PLTStub regs _ _ ->
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ParsedJump regs _ -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ParsedBranch regs _ _ _ -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ParsedLookupTable _layout regs _idx _tbl  -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ParsedReturn regs -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ParsedArchTermStmt _ regs _ -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
     ParsedTranslateError _ -> do
       pure ()
     ClassifyFailure regs _ -> do
-      traverseF_ addValueDemands regs
+      TF.traverseF_ addValueDemands regs
 
 -- | Eliminate all dead statements in blocks
 dropUnusedCodeInParsedBlock :: ArchitectureInfo arch
@@ -242,33 +221,6 @@ dropUnusedCodeInParsedBlock ainfo b =
           runDemandComp (archDemandContext ainfo) $ do
             addParsedBlockDemands b
         stmtPred = stmtNeeded demandSet
-
-------------------------------------------------------------------------
--- Memory utilities
-
-sliceMemContents'
-  :: MemWidth w
-  => Int -- ^ Number of bytes in each slice.
-  -> [[MemChunk w]] -- ^ Previous slices
-  -> Integer -- ^ Number of slices to return
-  -> [MemChunk w] -- ^ Ranges to process next
-  -> Either (SplitError w) ([[MemChunk w]],[MemChunk w])
-sliceMemContents' stride prev c next
-  | c <= 0 = pure (reverse prev, next)
-  | otherwise =
-    case splitMemChunks next stride of
-      Left e -> Left e
-      Right (this, rest) -> sliceMemContents' stride (this:prev) (c-1) rest
-
--- | @sliceMemContents stride cnt contents@ splits contents up into @cnt@
--- memory regions each with size @stride@.
-sliceMemContents
-  :: MemWidth w
-  => Int -- ^ Number of bytes in each slice.
-  -> Integer -- ^ Number of slices to return
-  -> [MemChunk w] -- ^ Ranges to process next
-  -> Either (SplitError w) ([[MemChunk w]],[MemChunk w])
-sliceMemContents stride c next = sliceMemContents' stride [] c next
 
 ------------------------------------------------------------------------
 -- DiscoveryState utilities
@@ -322,7 +274,7 @@ markAddrsAsFunction :: Foldable t
 markAddrsAsFunction rsn addrs s0 =
   let ins s a | shouldExploreFunction a s = s & unexploredFunctions %~ Map.insert a rsn
               | otherwise = s
-   in foldl' ins s0 addrs
+   in F.foldl' ins s0 addrs
 
 
 ------------------------------------------------------------------------
@@ -349,7 +301,7 @@ foundReasonL = lens foundReason (\old new -> old { foundReason = new })
 -- | The state for the function exploration monad (funM)
 data FunState arch s ids
    = FunState { funReason :: !(FunctionExploreReason (ArchAddrWidth arch))
-              , funNonceGen  :: !(NonceGenerator (STS.ST s) ids)
+              , funNonceGen  :: !(PN.NonceGenerator (STS.ST s) ids)
               , curFunAddr   :: !(ArchSegmentOff arch)
                 -- ^ Address of the function
               , _curFunCtx   :: !(DiscoveryState arch)
@@ -377,17 +329,17 @@ data FunState arch s ids
               }
 
 -- | Discovery info
-curFunCtx :: Simple Lens (FunState arch s ids)  (DiscoveryState arch)
+curFunCtx :: Lens' (FunState arch s ids)  (DiscoveryState arch)
 curFunCtx = lens _curFunCtx (\s v -> s { _curFunCtx = v })
 
 -- | Information about current function we are working on
-curFunBlocks :: Simple Lens (FunState arch s ids) (Map (ArchSegmentOff arch) (ParsedBlock arch ids))
+curFunBlocks :: Lens' (FunState arch s ids) (Map (ArchSegmentOff arch) (ParsedBlock arch ids))
 curFunBlocks = lens _curFunBlocks (\s v -> s { _curFunBlocks = v })
 
-foundAddrs :: Simple Lens (FunState arch s ids) (Map (ArchSegmentOff arch) (FoundAddr arch))
+foundAddrs :: Lens' (FunState arch s ids) (Map (ArchSegmentOff arch) (FoundAddr arch))
 foundAddrs = lens _foundAddrs (\s v -> s { _foundAddrs = v })
 
-newEntries :: Simple Lens (FunState arch s ids) (CandidateFunctionMap arch)
+newEntries :: Lens' (FunState arch s ids) (CandidateFunctionMap arch)
 newEntries = lens _newEntries (\s v -> s { _newEntries = v })
 
 -- | Add a block to the current function blocks. If this overlaps with an
@@ -416,26 +368,26 @@ type ReverseEdgeMap arch = Map (ArchSegmentOff arch) (Set (ArchSegmentOff arch))
 
 -- | Maps each code address to the list of predecessors that
 -- affected its abstract state.
-reverseEdges :: Simple Lens (FunState arch s ids) (ReverseEdgeMap arch)
+reverseEdges :: Lens' (FunState arch s ids) (ReverseEdgeMap arch)
 reverseEdges = lens _reverseEdges (\s v -> s { _reverseEdges = v })
 
 -- | Set of addresses to explore next.
 --
 -- This is a map so that we can associate a reason why a code address
 -- was added to the frontier.
-frontier :: Simple Lens (FunState arch s ids) (Set (ArchSegmentOff arch))
+frontier :: Lens' (FunState arch s ids) (Set (ArchSegmentOff arch))
 frontier = lens _frontier (\s v -> s { _frontier = v })
 
 ------------------------------------------------------------------------
 -- FunM
 
 -- | A newtype around a function
-newtype FunM arch s ids a = FunM { unFunM :: StateT (FunState arch s ids) (STL.ST s) a }
+newtype FunM arch s ids a = FunM { unFunM :: CMS.StateT (FunState arch s ids) (STL.ST s) a }
   deriving (Functor, Applicative, Monad)
 
-instance MonadState (FunState arch s ids) (FunM arch s ids) where
-  get = FunM $ get
-  put s = FunM $ put s
+instance CMS.MonadState (FunState arch s ids) (FunM arch s ids) where
+  get = FunM $ CMS.get
+  put s = FunM $ CMS.put s
 
 ------------------------------------------------------------------------
 -- Transfer functions
@@ -445,7 +397,7 @@ instance MonadState (FunState arch s ids) (FunM arch s ids) where
 mergeIntraJump  :: ArchitectureInfo arch
                 -> ArchSegmentOff arch
                   -- ^ Source label that we are jumping from.
-                -> IntraJumpTarget arch
+                -> Jmp.IntraJumpTarget arch
                    -- ^ Target we are jumping to.
                 -> FunM arch s ids ()
 mergeIntraJump info src (tgt, ab, bnds) = do
@@ -476,307 +428,6 @@ mergeIntraJump info src (tgt, ab, bnds) = do
                                 }
       foundAddrs %= Map.insert tgt foundInfo
 
--------------------------------------------------------------------------------
--- BoundedMemArray recognition
-
-absValueAsSegmentOff
-  :: forall w
-  .  Memory w
-  -> AbsValue w (BVType  w)
-  -> Maybe (MemSegmentOff w)
-absValueAsSegmentOff mem av = case av of
-  FinSet s | Set.size s == 1 -> resolveAbsoluteIntegerAddr (shead s)
-  CodePointers s False | Set.size s == 1 -> Just (shead s)
-  CodePointers s True  | Set.size s == 0 -> resolveAbsoluteIntegerAddr 0
-  StridedInterval si -> SI.isSingleton si >>= resolveAbsoluteIntegerAddr
-  _ -> Nothing
-  where
-  shead :: Set a -> a
-  shead = Set.findMin
-
-  resolveAbsoluteIntegerAddr :: Integer -> Maybe (MemSegmentOff w)
-  resolveAbsoluteIntegerAddr = resolveAbsoluteAddr mem . addrWidthClass (memAddrWidth mem) fromInteger
-
--- | This attempts to interpret a value as a memory segment offset
--- using the memory and abstract interpretation of value.
-valueAsSegmentOffWithTransfer
-  :: forall arch ids
-  .  RegisterInfo (ArchReg arch)
-  => Memory (ArchAddrWidth arch)
-  -> AbsProcessorState (ArchReg arch) ids
-  -> BVValue arch ids (ArchAddrWidth arch)
-  -> Maybe (ArchSegmentOff arch)
-valueAsSegmentOffWithTransfer mem aps base
-  =   valueAsSegmentOff mem base
-  <|> absValueAsSegmentOff mem (transferValue aps base)
-
--- | This attempts to pattern match a value as a memory address plus a value.
-valueAsMemOffset
-  :: RegisterInfo (ArchReg arch)
-  => Memory (ArchAddrWidth arch)
-  -> AbsProcessorState (ArchReg arch) ids
-  -> ArchAddrValue arch ids
-  -> Maybe (ArchSegmentOff arch, ArchAddrValue arch ids)
-valueAsMemOffset mem aps v
-  | Just (BVAdd _ base offset) <- valueAsApp v
-  , Just ptr <- valueAsSegmentOffWithTransfer mem aps base
-  = Just (ptr, offset)
-
-  -- and with the other argument order
-  | Just (BVAdd _ offset base) <- valueAsApp v
-  , Just ptr <- valueAsSegmentOffWithTransfer mem aps base
-  = Just (ptr, offset)
-
-  | otherwise = Nothing
-
--- | This operation extracts chunks of memory for a jump table.
-extractJumpTableSlices :: ArchConstraints arch
-                       => Jmp.IntraJumpBounds arch ids
-                       -- ^ Bounds for jump table
-                       -> MemSegmentOff (ArchAddrWidth arch) -- ^ Base address
-                       -> Natural -- ^ Stride
-                       -> BVValue arch ids idxWidth
-                       -> MemRepr tp -- ^ Type of values
-                       -> Classifier (V.Vector [MemChunk (ArchAddrWidth arch)])
-extractJumpTableSlices jmpBounds base stride ixVal tp = do
-  cnt <-
-    case Jmp.unsignedUpperBound jmpBounds ixVal of
-      Nothing -> fail $ "Upper bounds failed:\n"
-                      ++ show (ppValueAssignments ixVal) ++ "\n"
-                      ++ show (pretty jmpBounds)
-      Just bnd -> do
-        let cnt = toInteger (bnd+1)
-        -- Check array actually fits in memory.
-        when (cnt * toInteger stride > segoffBytesLeft base) $ do
-          fail "Size is too large."
-        pure cnt
-
-  -- Get memory contents after base
-  Right contents <- pure $ segoffContentsAfter base
-  -- Break up contents into a list of slices each with size stide
-  Right (strideSlices,_) <- pure $ sliceMemContents (fromIntegral stride) cnt contents
-  -- Get memory slices
-  Right slices <-
-    pure $ traverse (\s -> fst <$> splitMemChunks s (fromIntegral (memReprBytes tp)))
-                    (V.fromList strideSlices)
-  pure slices
-
--- | @matchBoundedMemArray mem aps bnds val@ checks to try to interpret
--- @val@ as a memory read where
---
--- * the address read has the form @base + stride * ixVal@,
--- * @base@ is a valid `MemSegmentOff`,
--- * @stride@ is a natural number and,
--- * @ixVal@ is a arbitrary value.
-matchBoundedMemArray
-  :: ArchConstraints arch
-  => Memory (ArchAddrWidth arch)
-  -> AbsProcessorState (ArchReg arch) ids
-  -> Jmp.IntraJumpBounds arch ids
-     -- ^ Bounds for jump table
-  -> Value arch ids tp  -- ^ Value to interpret
-  -> Classifier (BoundedMemArray arch tp, ArchAddrValue arch ids)
-matchBoundedMemArray mem aps jmpBounds val = do
-  AssignedValue (Assignment _ (ReadMem addr tp)) <- pure val
-  Just (base, offset) <- pure $ valueAsMemOffset mem aps addr
-  Just (stride, ixVal) <- pure $ valueAsStaticMultiplication offset
-   -- Check stride covers at least number of bytes read.
-  when (memReprBytes tp > stride) $ do
-    fail "Stride does not cover size of relocation."
-  -- Convert stride to word64 (must be lossless due to as memory is at most 64-bits)
-  let stridew :: Word64
-      stridew = fromIntegral stride
-  -- Take the given number of bytes out of each slices
-  slices <- extractJumpTableSlices jmpBounds base stride ixVal tp
-
-  let r = BoundedMemArray
-          { arBase     = base
-          , arStride   = stridew
-          , arEltType  = tp
-          , arSlices   = slices
-          }
-  pure  (r, ixVal)
-
-------------------------------------------------------------------------
--- Extension
-
--- | Just like Some (BVValue arch ids), but doesn't run into trouble with
--- partially applying the BVValue type synonym.
-data SomeExt arch ids = forall m . SomeExt !(BVValue arch ids m) !(Extension m)
-
-matchAddr :: NatRepr w -> Maybe (AddrWidthRepr w)
-matchAddr w
-  | Just Refl <- testEquality w n32 = Just Addr32
-  | Just Refl <- testEquality w n64 = Just Addr64
-  | otherwise = Nothing
-
--- | @matchExtension x@ matches in @x@ has the form @uext y w@ or @sext y w@ and returns
--- a description about the extension as well as the pattern @y@.
-matchExtension :: forall arch ids
-               .  ( MemWidth (ArchAddrWidth arch)
-                  , HasRepr (ArchReg arch) TypeRepr)
-               => ArchAddrValue arch ids
-               -> SomeExt arch ids
-matchExtension val =
-  case valueAsApp val of
-    Just (SExt val' _w) | Just repr <- matchAddr (typeWidth val') -> SomeExt val' (Extension True  repr)
-    Just (UExt val' _w) | Just repr <- matchAddr (typeWidth val') -> SomeExt val' (Extension False repr)
-    _ -> SomeExt val (Extension False (addrWidthRepr @(ArchAddrWidth arch) undefined))
-
--- | `extendDyn ext end bs` parses the bytestring using the extension
--- and endianness information, and returns the extended value.
-extendDyn :: Extension w -> Endianness -> BS.ByteString -> Integer
-extendDyn (Extension False Addr32) end bs  = toInteger (bsWord32 end bs)
-extendDyn (Extension False Addr64) end bs  = toInteger (bsWord64 end bs)
-extendDyn (Extension True  Addr32) end bs = toInteger (fromIntegral (bsWord32 end bs) :: Int32)
-extendDyn (Extension True  Addr64) end bs = toInteger (fromIntegral (bsWord64 end bs) :: Int64)
-
---------------------------------------------------------------------------------
--- Jump table recognition
-
--- This function resolves jump table entries.
--- It is a recursive function that has an index into the jump table.
--- If the current index can be interpreted as a intra-procedural jump,
--- then it will add that to the current procedure.
--- This returns the last address read.
-resolveAsAddr :: forall w
-              .  Memory w
-              -> Endianness
-              -> [MemChunk w]
-              -> Maybe (MemAddr w)
-resolveAsAddr mem endianness l = addrWidthClass (memAddrWidth mem) $
-  case l of
-    [ByteRegion bs] ->
-      case addrRead endianness bs of
-        Just a -> pure $! absoluteAddr a
-        Nothing -> error $ "internal: resolveAsAddr given short chunk list."
-    [RelocationRegion r] -> do
-        when (relocationIsRel r) $ Nothing
-        case relocationSym r of
-          SymbolRelocation{} -> Nothing
-          SectionIdentifier idx -> do
-            addr <- Map.lookup idx (memSectionIndexMap mem)
-            pure $! segoffAddr addr & incAddr (toInteger (relocationOffset r))
-          SegmentBaseAddr idx -> do
-            seg <- Map.lookup idx (memSegmentIndexMap mem)
-            pure $! segmentOffAddr seg (relocationOffset r)
-          LoadBaseAddr -> do
-            memBaseAddr mem
-    _ -> Nothing
-
--- This function resolves jump table entries.
--- It is a recursive function that has an index into the jump table.
--- If the current index can be interpreted as a intra-procedural jump,
--- then it will add that to the current procedure.
--- This returns the last address read.
-resolveRelativeJumps :: forall arch w
-                        .  ( MemWidth (ArchAddrWidth arch)
-                        , IPAlignment arch
-                        , RegisterInfo (ArchReg arch)
-                        )
-                     => Memory (ArchAddrWidth arch)
-                     -> ArchSegmentOff arch
-           --          -> MemRepr (BVType w)
-                     -> BoundedMemArray arch (BVType w)
-                     -> Extension w
-                     -> Either String (V.Vector (ArchSegmentOff arch))
-resolveRelativeJumps mem base arrayRead ext = do
-  let slices = arSlices arrayRead
-  let BVMemRepr _ endianness = arEltType arrayRead
-  forM slices $ \l -> do
-    bs <- case l of
-            [ByteRegion bs] -> Right bs
-            _ -> Left $ "Could not recognize slice: " <> show l
-    let tgtAddr = segoffAddr base & incAddr (extendDyn ext endianness bs)
-
-    let brRepr = unwords [ showHex w "" | w <- BS.unpack bs ]
-
-    tgt <- case asSegmentOff mem (toIPAligned @arch tgtAddr) of
-             Just tgt -> Right tgt
-             _ -> Left $ "Could not resolve " <> show (ext, endianness, base, brRepr)
-
-    unless (Perm.isExecutable (segmentFlags (segoffSegment tgt))) $ do
-      Left "Address is not executable."
-
-    Right tgt
-
--- | Contains information about jump table layout, addresses and index
--- in a recognized jump table.
-type JumpTableClassifierResult arch ids =
-   (JumpTableLayout arch, V.Vector (ArchSegmentOff arch), ArchAddrValue arch ids)
-
-type JumpTableClassifier arch ids s =
-  ReaderT (BlockClassifierContext arch ids) Classifier (JumpTableClassifierResult arch ids)
-
--- | @matchAbsoluteJumpTable@ tries to match the control flow transfer
--- as a jump table where the addresses in the jump table are absolute
--- memory addresses.
-matchAbsoluteJumpTable
-  :: forall arch ids s
-  .  ArchConstraints arch
-  => JumpTableClassifier arch ids s
-matchAbsoluteJumpTable = classifierName "Absolute jump table" $ do
-  bcc <- ask
-  let mem = pctxMemory (classifierParseContext bcc)
-  let aps = classifierAbsState bcc
-  let jmpBounds = classifierJumpBounds bcc
-  -- Get IP value to interpret as a jump table index.
-  let ip = classifierFinalRegState bcc^.curIP
-  (arrayRead, idx) <- lift $ matchBoundedMemArray mem aps jmpBounds ip
-  unless (isReadOnlyBoundedMemArray arrayRead) $ do
-    fail "Bounded mem array is not read only."
-  endianness <-
-    case arEltType arrayRead of
-      BVMemRepr _arByteCount e -> pure e
-  let go :: Int
-         -> [MemChunk (ArchAddrWidth arch)]
-         -> Classifier (MemSegmentOff (ArchAddrWidth arch))
-      go entryIndex contents = do
-        addr <- case resolveAsAddr mem endianness contents of
-                  Just a -> pure a
-                  Nothing -> fail "Could not resolve jump table contents as absolute address."
-        tgt <- case asSegmentOff mem (toIPAligned @arch addr) of
-                 Just t -> pure t
-                 Nothing ->
-                   fail $
-                     "Could not resolve jump table entry " ++ show entryIndex
-                     ++ " value " ++ show addr ++ " as segment offset.\n" ++ show mem
-        unless (Perm.isExecutable (segmentFlags (segoffSegment tgt))) $
-          fail $ "Jump table contents non-executable."
-        pure tgt
-  tbl <- lift $ V.zipWithM go (V.generate (V.length (arSlices arrayRead)) id) (arSlices arrayRead)
-  pure (AbsoluteJumpTable arrayRead, tbl, idx)
-
--- | @matchAbsoluteJumpTable@ tries to match the control flow transfer
--- as a jump table where the addresses in the jump table are IP relative jumps.
-matchRelativeJumpTable
-  :: forall arch ids s
-  .  ArchConstraints arch
-  => JumpTableClassifier arch ids s
-matchRelativeJumpTable = classifierName "Relative jump table" $ do
-  bcc <- ask
-  let mem = pctxMemory (classifierParseContext bcc)
-  let aps = classifierAbsState bcc
-  let jmpBounds = classifierJumpBounds bcc
-  -- Get IP value to interpret as a jump table index.
-  let ip = classifierFinalRegState bcc^.curIP
-
-  -- gcc-style PIC jump tables on x86 use, roughly,
-  --     ip = jmptbl + jmptbl[index]
-  -- where jmptbl is a pointer to the lookup table.
-  Just unalignedIP <- pure $ fromIPAligned ip
-  (tgtBase, tgtOffset) <-
-    case valueAsMemOffset mem aps unalignedIP of
-      Just p -> pure p
-      Nothing -> fail $ "Unaligned IP not a mem offset: " <> show unalignedIP
-  SomeExt shortOffset ext <- pure $ matchExtension tgtOffset
-  (arrayRead, idx) <- lift $ matchBoundedMemArray mem aps jmpBounds shortOffset
-  unless (isReadOnlyBoundedMemArray arrayRead) $ do
-    fail $ "Jump table memory array must be read only."
-  tbl <- case resolveRelativeJumps mem tgtBase arrayRead ext of
-           Left msg -> fail msg
-           Right tbl -> pure tbl
-  pure (RelativeJumpTable tgtBase arrayRead ext, tbl, idx)
 
 ------------------------------------------------------------------------
 -- recordWriteStmts
@@ -799,7 +450,7 @@ recordWriteStmts ainfo mem absState writtenAddrs (stmt:stmts) =
     let writtenAddrs' =
           case stmt of
             WriteMem _addr repr v
-              | Just Refl <- testEquality repr (addrMemRepr ainfo) ->
+              | Just PC.Refl <- PC.testEquality repr (addrMemRepr ainfo) ->
                 withArchConstraints ainfo $
                   let addrs = identifyConcreteAddresses mem (transferValue absState v)
                    in addrs ++ writtenAddrs
@@ -807,28 +458,6 @@ recordWriteStmts ainfo mem absState writtenAddrs (stmt:stmts) =
               writtenAddrs
     recordWriteStmts ainfo mem absState' writtenAddrs' stmts
 
-------------------------------------------------------------------------
--- ParseContext
-
--- | Information needed to parse the processor state
-data ParseContext arch ids =
-  ParseContext { pctxMemory         :: !(Memory (ArchAddrWidth arch))
-               , pctxArchInfo       :: !(ArchitectureInfo arch)
-               , pctxKnownFnEntries :: !(Map (ArchSegmentOff arch) NoReturnFunStatus)
-                 -- ^ Entry addresses for known functions (e.g. from
-                 -- symbol information)
-                 --
-                 -- The discovery process will not create
-                 -- intra-procedural jumps to the entry points of new
-                 -- functions.
-               , pctxFunAddr        :: !(ArchSegmentOff arch)
-                 -- ^ Address of function containing this block.
-               , pctxAddr           :: !(ArchSegmentOff arch)
-                 -- ^ Address of the current block
-               , pctxExtResolution :: [(ArchSegmentOff arch, [ArchSegmentOff arch])]
-                 -- ^ Externally-provided resolutions for classification
-                 -- failures, which are used in parseFetchAndExecute
-               }
 
 -- | Get the memory representation associated with pointers in the
 -- given architecture.
@@ -838,586 +467,11 @@ addrMemRepr arch_info =
     Addr32 -> BVMemRepr n4 (archEndianness arch_info)
     Addr64 -> BVMemRepr n8 (archEndianness arch_info)
 
--- | Identify new potentialfunction entry points by looking at IP.
-identifyCallTargets :: forall arch ids
-                    .  (RegisterInfo (ArchReg arch))
-                    => Memory (ArchAddrWidth arch)
-                    -> AbsProcessorState (ArchReg arch) ids
-                       -- ^ Abstract processor state just before call.
-                    -> RegState (ArchReg arch) (Value arch ids)
-                    -> [ArchSegmentOff arch]
-identifyCallTargets mem absState regs = do
-  -- Code pointers from abstract domains.
-  let def = identifyConcreteAddresses mem $ transferValue absState (regs^.boundValue ip_reg)
-  case regs^.boundValue ip_reg of
-    BVValue _ x ->
-      maybeToList $ resolveAbsoluteAddr mem (fromInteger x)
-    RelocatableValue _ a ->
-      maybeToList $ asSegmentOff mem a
-    SymbolValue{} -> []
-    AssignedValue a ->
-      case assignRhs a of
-        -- See if we can get a value out of a concrete memory read.
-        ReadMem addr (BVMemRepr _ end)
-          | Just laddr <- valueAsMemAddr addr
-          , Right val <- readSegmentOff mem end laddr ->
-            val : def
-        _ -> def
-    Initial _ -> def
-
--- | @stripPLTRead assignId prev rest@ looks for a read of @assignId@
--- from the end of @prev@, and if it finds it returns the
--- concatenation of the instruction before the read in @prev@ and
--- @rest@.
---
--- The read may appear before comment and @instructionStart@
--- instructions, but otherwise must be at the end of the instructions
--- in @prev@.
-stripPLTRead :: forall arch ids tp
-               . ArchConstraints arch
-              => AssignId ids tp -- ^ Identifier of write to remove
-              -> Seq (Stmt arch ids)
-              -> Seq (Stmt arch ids)
-              -> Maybe (Seq (Stmt arch ids))
-stripPLTRead readId next rest =
-  case Seq.viewr next of
-    Seq.EmptyR -> Nothing
-    prev Seq.:> lastStmt -> do
-      let cont = stripPLTRead readId prev (lastStmt Seq.<| rest)
-      case lastStmt of
-        AssignStmt (Assignment stmtId rhs)
-          | Just Refl <- testEquality readId stmtId ->
-              Just (prev Seq.>< fmap (dropRefsTo stmtId) rest)
-            -- Fail if the read to delete is used in later computations
-          | Set.member (Some readId) (foldMapFC refsInValue rhs) ->
-              Nothing
-          | otherwise ->
-            case rhs of
-              EvalApp{} -> cont
-              SetUndefined{} -> cont
-              _ -> Nothing
-        InstructionStart{} -> cont
-        ArchState{} -> cont
-        Comment{} -> cont
-        _ -> Nothing
-  where
-    -- It is possible for later ArchState updates to reference the AssignId of
-    -- the AssignStmt that is dropped, so make sure to prune such updates to
-    -- avoid referencing the now out-of-scope AssignId.
-    dropRefsTo :: AssignId ids tp -> Stmt arch ids -> Stmt arch ids
-    dropRefsTo stmtId stmt =
-      case stmt of
-        ArchState addr updates ->
-          ArchState addr $
-          MapF.filter (\v -> Some stmtId `Set.notMember` refsInValue v) updates
-
-        -- These Stmts don't contain any Values.
-        InstructionStart{} -> stmt
-        Comment{}          -> stmt
-
-        -- stripPLTRead will bail out if it encounters any of these forms of
-        -- Stmt, so we don't need to consider them.
-        AssignStmt{}   -> stmt
-        ExecArchStmt{} -> stmt
-        CondWriteMem{} -> stmt
-        WriteMem{}     -> stmt
-
-removeUnassignedRegs :: forall arch ids
-                     .  RegisterInfo (ArchReg arch)
-                     => RegState (ArchReg arch) (Value arch ids)
-                        -- ^ Initial register values
-                     -> RegState (ArchReg arch) (Value arch ids)
-                        -- ^ Final register values
-                     -> MapF.MapF (ArchReg arch) (Value arch ids)
-removeUnassignedRegs initRegs finalRegs =
-  let keepReg :: forall tp . ArchReg arch tp -> Value arch ids tp -> Bool
-      keepReg r finalVal
-         | Just Refl <- testEquality r ip_reg = False
-         | Just Refl <- testEquality initVal finalVal = False
-         | otherwise = True
-        where initVal = initRegs^.boundValue r
-   in MapF.filterWithKey keepReg (regStateMap finalRegs)
-
--- | Return true if any value in structure contains the given
--- identifier.
-containsAssignId :: forall t arch ids itp
-                 .  FoldableF t
-                 => AssignId ids itp
-                    -- ^ Forbidden assignment -- may not appear in terms.
-                 -> t (Value arch ids)
-                 -> Bool
-containsAssignId droppedAssign =
-  let hasId :: forall tp . Value arch ids tp -> Any
-      hasId v = Any (Set.member (Some droppedAssign) (refsInValue v))
-   in getAny . foldMapF hasId
-
--- | Stores the main block features that may changes from parsing a block.
-data ParsedContents arch ids =
-  ParsedContents { parsedNonterm :: !([Stmt arch ids])
-                   -- ^ The non-terminal statements in the block
-                 , parsedTerm  :: !(ParsedTermStmt arch ids)
-                   -- ^ The terminal statement in the block.
-                 , writtenCodeAddrs :: ![ArchSegmentOff arch]
-                 -- ^ Addresses marked executable that were written to memory.
-                 , intraJumpTargets :: ![IntraJumpTarget arch]
-                 , newFunctionAddrs :: ![ArchSegmentOff arch]
-                   -- ^ List of candidate functions found when parsing block.
-                   --
-                   -- Note. In a binary, these could denote the non-executable
-                   -- segments, so they are filtered before traversing.
-                 }
-
--- | @normBool b q@ returns a pair where for each `NotApp` applied to @b@, we recursively
--- take the argument to `NotApp` and the Boolean.
---
--- This is used to compare if one value is equal to or the syntactic
--- complement of another value.
-normBool :: Value arch ids BoolType -> Bool -> (Value arch ids BoolType, Bool)
-normBool x b
-  | AssignedValue a <- x
-  , EvalApp (NotApp xn) <- assignRhs a =
-      normBool xn (not b)
-  | otherwise = (x,b)
-
--- | This computes the abstract state for the start of a block for a
--- given branch target.  It is used so that we can make use of the
--- branch condition to simplify the abstract state.
-branchBlockState :: forall a ids t
-               .  ( Foldable t
-                  )
-               => ArchitectureInfo a
-               -> AbsProcessorState (ArchReg a) ids
-               -> t (Stmt a ids)
-               -> RegState (ArchReg a) (Value a ids)
-                  -- ^  Register values
-               -> Value a ids BoolType
-                  -- ^ Branch condition
-               -> Bool
-                  -- ^ Flag indicating if branch is true or false.
-               -> AbsBlockState (ArchReg a)
-branchBlockState ainfo ps0 stmts regs c0 isTrue0 =
-  withArchConstraints ainfo $
-    let (c,isTrue) = normBool c0 isTrue0
-        ps = refineProcState c isTrue ps0
-        mapReg :: ArchReg a tp -> Value a ids tp -> Value a ids tp
-        mapReg _r v
-          | AssignedValue a <- v
-          , EvalApp (Mux _ cv0 tv fv) <- assignRhs a
-          , (cv, b) <- normBool cv0 isTrue
-          , cv == c =
-              if b then tv else fv
-          | otherwise =
-              v
-        refinedRegs = mapRegsWith mapReg regs
-     in finalAbsBlockState (foldl' (absEvalStmt ainfo) ps stmts) refinedRegs
-
-type ClassificationError = String
-
-data Classifier o = ClassifyFailed    [ClassificationError]
-                  | ClassifySucceeded [ClassificationError] o
-
-classifierName :: String -> ReaderT i Classifier a -> ReaderT i Classifier a
-classifierName nm (ReaderT m) = ReaderT $ \i ->
-  case m i of
-    ClassifyFailed [] -> ClassifyFailed [nm ++ " classification failed."]
-    ClassifyFailed l  -> ClassifyFailed (fmap ((nm ++ ": ") ++)  l)
-    ClassifySucceeded l a -> ClassifySucceeded (fmap ((nm ++ ": ") ++)  l) a
-
-classifyFail :: Classifier a
-classifyFail = ClassifyFailed []
-
-classifySuccess :: a -> Classifier a
-classifySuccess = \x -> ClassifySucceeded [] x
-
-classifyBind :: Classifier a -> (a -> Classifier b) -> Classifier b
-classifyBind m f =
-  case m of
-    ClassifyFailed e -> ClassifyFailed e
-    ClassifySucceeded [] a -> f a
-    ClassifySucceeded l a ->
-      case f a of
-        ClassifyFailed    e   -> ClassifyFailed    (l++e)
-        ClassifySucceeded e b -> ClassifySucceeded (l++e) b
-
-classifyAppend :: Classifier a -> Classifier a -> Classifier a
-classifyAppend m n =
-  case m of
-    ClassifySucceeded e a -> ClassifySucceeded e a
-    ClassifyFailed [] -> n
-    ClassifyFailed e ->
-      case n of
-        ClassifySucceeded f a -> ClassifySucceeded (e++f) a
-        ClassifyFailed f      -> ClassifyFailed    (e++f)
-
-instance Alternative Classifier where
-  empty = classifyFail
-  (<|>) = classifyAppend
-
-instance Functor Classifier where
-  fmap = liftA
-
-instance Applicative Classifier where
-  pure = classifySuccess
-  (<*>) = ap
-
-instance Monad Classifier where
-  (>>=) = classifyBind
-#if !(MIN_VERSION_base(4,13,0))
-  fail = Fail.fail
-#endif
-
-instance Fail.MonadFail Classifier where
-  fail = \m -> ClassifyFailed [m]
-
-
-{-| The fields of the 'BlockClassifierContext' are:
-
-  [@ParseContext ...@]: The context for the parse
-
-  [@RegState ...@]: Initial register values
-
-  [@Seq (Stmt ...)@]: The statements in the block
-
-  [@AbsProcessorState ...@]: Abstract state of registers prior to
-                             terminator statement being executed.
-
-  [@Jmp.IntraJumpBounds ...@]: Bounds prior to terminator statement
-                               being executed.
-
-  [@ArchSegmentOff arch@]: Address of all segments written to memory
-
-  [@RegState ...@]: Final register values
--}
-data BlockClassifierContext arch ids = BlockClassifierContext
-  { classifierParseContext  :: !(ParseContext arch ids)
-  -- ^ Information needed to construct abstract processor states
-  , classifierInitRegState  :: !(RegState (ArchReg arch) (Value arch ids))
-  -- ^ The (concrete) register state at the beginning of the block
-  , classifierStmts         :: !(Seq (Stmt arch ids))
-  -- ^ The statements of the block (without the terminator)
-  , classifierBlockSize     :: !Int
-    -- ^ Size of block being classified.
-  , classifierAbsState      :: !(AbsProcessorState (ArchReg arch) ids)
-  -- ^ The abstract processor state before the terminator is executed
-  , classifierJumpBounds    :: !(Jmp.IntraJumpBounds arch ids)
-  -- ^ The relational abstract processor state before the terminator is executed
-  , classifierWrittenAddrs  :: !([ArchSegmentOff arch])
-  -- ^ The addresses of observed memory writes in the block
-  , classifierFinalRegState :: !(RegState (ArchReg arch) (Value arch ids))
-  -- ^ The final (concrete) register state before the terminator is executed
-  }
-
-classifierEndBlock :: BlockClassifierContext arch ids
-                   -> MemAddr (ArchAddrWidth arch)
-classifierEndBlock ctx = withArchConstraints (pctxArchInfo (classifierParseContext ctx)) $
-  let blockStart = segoffAddr (pctxAddr (classifierParseContext ctx))
-   in incAddr (toInteger (classifierBlockSize ctx)) blockStart
-
-type BlockClassifier arch ids =
-  ReaderT (BlockClassifierContext arch ids)
-          Classifier
-          (ParsedContents arch ids)
-
-classifyDirectJump :: RegisterInfo (ArchReg arch)
-                   => ParseContext arch ids
-                   -> String
-                   -> Value arch ids (BVType (ArchAddrWidth arch))
-                   -> ReaderT i Classifier (MemSegmentOff (ArchAddrWidth arch))
-classifyDirectJump ctx nm v = do
-  ma <- case valueAsMemAddr v of
-          Nothing ->  fail $ nm ++ " value " ++ show v ++ " is not a valid address."
-          Just a -> pure a
-  a <- case asSegmentOff (pctxMemory ctx) ma of
-         Nothing ->
-           fail $ nm ++ " value " ++ show v ++ " is not a segment offset in " ++ show (pctxMemory ctx) ++ "."
-         Just sa -> pure sa
-  when (not (segmentFlags (segoffSegment a) `Perm.hasPerm` Perm.execute)) $ do
-    fail $ nm ++ " value " ++ show a ++ " is not executable."
-  when (a == pctxFunAddr ctx) $ do
-    fail $ nm ++ " value " ++ show a ++ " refers to function start."
-  when (a `Map.member` pctxKnownFnEntries ctx) $ do
-    fail $ nm ++ " value " ++ show a ++ " is a known function entry."
-  pure a
-
-branchClassifier :: BlockClassifier arch ids
-branchClassifier = classifierName "Branch" $ do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  let finalRegs = classifierFinalRegState bcc
-  let writtenAddrs = classifierWrittenAddrs bcc
-  let absState = classifierAbsState bcc
-  let stmts = classifierStmts bcc
-  let ainfo = pctxArchInfo ctx
-  withArchConstraints ainfo $ do
-    -- The block ends with a Mux, so we turn this into a `ParsedBranch` statement.
-    let ipVal = finalRegs^.boundValue ip_reg
-    (c,t,f) <- case valueAsApp ipVal of
-                 Just (Mux _ c t f) -> pure (c,t,f)
-                 _ -> fail $ "IP is not an mux:\n"
-                          ++ show (ppValueAssignments ipVal)
-    trueTgtAddr  <- classifyDirectJump ctx "True branch"  t
-    falseTgtAddr <- classifyDirectJump ctx "False branch" f
-
-    let trueRegs  = finalRegs & boundValue ip_reg .~ t
-    let falseRegs = finalRegs & boundValue ip_reg .~ f
-
-    let trueAbsState  = branchBlockState ainfo absState stmts trueRegs c True
-    let falseAbsState = branchBlockState ainfo absState stmts falseRegs c False
-    let jmpBounds = classifierJumpBounds bcc
-    case Jmp.postBranchBounds jmpBounds finalRegs c of
-      Jmp.BothFeasibleBranch trueJmpState falseJmpState -> do
-        pure $ ParsedContents { parsedNonterm = toList stmts
-                              , parsedTerm  =
-                                  ParsedBranch finalRegs c trueTgtAddr falseTgtAddr
-                              , writtenCodeAddrs = writtenAddrs
-                              , intraJumpTargets =
-                                  [ (trueTgtAddr,  trueAbsState,  trueJmpState)
-                                  , (falseTgtAddr, falseAbsState, falseJmpState)
-                                  ]
-                              , newFunctionAddrs = []
-                              }
-      -- The false branch is impossible.
-      Jmp.TrueFeasibleBranch trueJmpState -> do
-        pure $ ParsedContents { parsedNonterm = toList stmts
-                              , parsedTerm  = ParsedJump finalRegs trueTgtAddr
-                              , writtenCodeAddrs = writtenAddrs
-                              , intraJumpTargets =
-                                  [(trueTgtAddr, trueAbsState, trueJmpState)]
-                              , newFunctionAddrs = []
-                              }
-      -- The true branch is impossible.
-      Jmp.FalseFeasibleBranch falseJmpState -> do
-        pure $ ParsedContents { parsedNonterm = toList stmts
-                              , parsedTerm  = ParsedJump finalRegs falseTgtAddr
-                              , writtenCodeAddrs = writtenAddrs
-                              , intraJumpTargets =
-                                  [(falseTgtAddr, falseAbsState, falseJmpState)]
-                              , newFunctionAddrs = []
-                              }
-      -- Both branches were deemed impossible
-      Jmp.InfeasibleBranch -> do
-        fail $ "Branch targets are both unreachable."
-
--- |  Use architecture-specific callback to check if last statement was a call.
---
--- Note that in some cases the call is known not to return, and thus
--- this code will never jump to the return value.
-callClassifier :: BlockClassifier arch ids
-callClassifier = do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  let finalRegs = classifierFinalRegState bcc
-  let ainfo = pctxArchInfo ctx
-  let mem = pctxMemory ctx
-  ret <- case identifyCall ainfo mem (classifierStmts bcc) finalRegs of
-           Just (_prev_stmts, ret) -> pure ret
-           Nothing -> fail $ "Call classifer failed."
-  withArchConstraints ainfo $ do
-    pure $ ParsedContents { parsedNonterm = toList (classifierStmts bcc)
-                          , parsedTerm  = ParsedCall finalRegs (Just ret)
-                            -- The return address may be written to
-                            -- stack, but is highly unlikely to be
-                            -- a function entry point.
-                          , writtenCodeAddrs = filter (\a -> a /= ret) (classifierWrittenAddrs bcc)
-                            --Include return target
-                          , intraJumpTargets =
-                              [( ret
-                               , postCallAbsState ainfo (classifierAbsState bcc) finalRegs ret
-                               , Jmp.postCallBounds (archCallParams ainfo) (classifierJumpBounds bcc) finalRegs
-                               )]
-                            -- Use the abstract domain to look for new code pointers for the current IP.
-                          , newFunctionAddrs = identifyCallTargets mem (classifierAbsState bcc) finalRegs
-                          }
-
--- | Check this block ends with a return as identified by the
--- architecture-specific processing.  Basic return identification
--- can be performed by detecting when the Instruction Pointer
--- (ip_reg) contains the 'ReturnAddr' symbolic value (initially
--- placed on the top of the stack or in the Link Register by the
--- architecture-specific state iniitializer).  However, some
--- architectures perform expression evaluations on this value before
--- loading the IP (e.g. ARM will clear the low bit in T32 mode or
--- the low 2 bits in A32 mode), so the actual detection process is
--- deferred to architecture-specific functionality.
-returnClassifier :: BlockClassifier arch ids
-returnClassifier = classifierName "Return" $ do
-  bcc <- ask
-  let ainfo = pctxArchInfo (classifierParseContext bcc)
-  withArchConstraints ainfo $ do
-    Just prevStmts <-
-      pure $ identifyReturn ainfo
-                            (classifierStmts bcc)
-                            (classifierFinalRegState bcc)
-                            (classifierAbsState bcc)
-    pure $ ParsedContents { parsedNonterm = toList prevStmts
-                          , parsedTerm = ParsedReturn (classifierFinalRegState bcc)
-                          , writtenCodeAddrs = classifierWrittenAddrs bcc
-                          , intraJumpTargets = []
-                          , newFunctionAddrs = []
-                          }
-
--- | Jumps concrete addresses are intra-procedural if the call
--- identification fails.
-directJumpClassifier :: BlockClassifier arch ids
-directJumpClassifier = classifierName "Jump" $ do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  let ainfo = pctxArchInfo ctx
-  withArchConstraints ainfo $ do
-
-    tgtMSeg <- classifyDirectJump ctx "Jump" (classifierFinalRegState bcc ^. boundValue ip_reg)
-
-    let abst = finalAbsBlockState (classifierAbsState bcc) (classifierFinalRegState bcc)
-    let abst' = abst & setAbsIP tgtMSeg
-    let tgtBnds = Jmp.postJumpBounds (classifierJumpBounds bcc) (classifierFinalRegState bcc)
-    pure $ ParsedContents { parsedNonterm = toList (classifierStmts bcc)
-                          , parsedTerm  = ParsedJump (classifierFinalRegState bcc) tgtMSeg
-                          , writtenCodeAddrs = classifierWrittenAddrs bcc
-                          , intraJumpTargets = [(tgtMSeg, abst', tgtBnds)]
-                          , newFunctionAddrs = []
-                          }
-
-jumpTableClassifier :: forall arch ids . BlockClassifier arch ids
-jumpTableClassifier = classifierName "Jump table" $ do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  let ainfo = pctxArchInfo ctx
-  let jmpBounds = classifierJumpBounds bcc
-  withArchConstraints ainfo $ do
-    let jumpTableClassifiers
-          =   matchAbsoluteJumpTable
-          <|> matchRelativeJumpTable
-    (layout, entries, jumpIndex) <- lift $
-      runReaderT jumpTableClassifiers bcc
-
-    let abst :: AbsBlockState (ArchReg arch)
-        abst = finalAbsBlockState (classifierAbsState bcc) (classifierFinalRegState bcc)
-    let nextBnds = Jmp.postJumpBounds jmpBounds (classifierFinalRegState bcc)
-    let term = ParsedLookupTable layout (classifierFinalRegState bcc) jumpIndex entries
-    pure $ seq abst $
-      ParsedContents { parsedNonterm = toList (classifierStmts bcc)
-                     , parsedTerm = term
-                     , writtenCodeAddrs = classifierWrittenAddrs bcc
-                     , intraJumpTargets =
-                         [ (tgtAddr, abst & setAbsIP tgtAddr, nextBnds)
-                         | tgtAddr <- V.toList entries
-                         ]
-                     , newFunctionAddrs = []
-                     }
-
--- | Attempt to recognize PLT stub
-pltStubClassifier :: BlockClassifier arch ids
-pltStubClassifier = classifierName "PLT stub" $ do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  let ainfo = pctxArchInfo ctx
-  let mem = pctxMemory ctx
-  withArchConstraints ainfo $ do
-
-    -- The IP should jump to an address in the .got, so try to compute that.
-    AssignedValue (Assignment valId v) <- pure $ classifierFinalRegState bcc ^. boundValue ip_reg
-    ReadMem gotVal _repr <- pure $ v
-    Just gotSegOff <- pure $ valueAsSegmentOff mem gotVal
-    -- The .got contents should point to a relocation to the function
-    -- that we will jump to.
-    Right chunks <- pure $ segoffContentsAfter gotSegOff
-    RelocationRegion r:_ <- pure $ chunks
-    -- Check the relocation satisfies all the constraints we expect on PLT strub
-    SymbolRelocation sym symVer <- pure $ relocationSym r
-    unless (relocationOffset r == 0) $ fail "PLT stub requires 0 offset."
-    when (relocationIsRel r) $ fail "PLT stub requires absolute relocation."
-    when (toInteger (relocationSize r) /= toInteger (addrWidthReprByteCount (archAddrWidth ainfo))) $ do
-      fail $ "PLT stub relocations must match address size."
-    when (relocationIsSigned r) $ do
-      fail $ "PLT stub relocations must be signed."
-    when (relocationEndianness r /= archEndianness ainfo) $ do
-      fail $ "PLT relocation endianness must match architecture."
-    unless (relocationJumpSlot r) $ do
-      fail $ "PLT relocations must be jump slots."
-    -- The PLTStub terminator will implicitly read the GOT address, so we remove
-    -- it from the list of statements.
-    Just strippedStmts <- pure $ stripPLTRead valId (classifierStmts bcc) Seq.empty
-    let strippedRegs = removeUnassignedRegs (classifierInitRegState bcc) (classifierFinalRegState bcc)
-    when (containsAssignId valId strippedRegs) $ do
-      fail $ "PLT IP must be assigned."
-    pure $ ParsedContents { parsedNonterm = toList strippedStmts
-                          , parsedTerm  = PLTStub strippedRegs gotSegOff (VerSym sym symVer)
-                          , writtenCodeAddrs = classifierWrittenAddrs bcc
-                          , intraJumpTargets = []
-                          , newFunctionAddrs = []
-                          }
-
-noreturnCallParsedContents :: BlockClassifierContext arch ids -> ParsedContents arch ids
-noreturnCallParsedContents bcc =
-  let ctx  = classifierParseContext bcc
-      mem  = pctxMemory ctx
-      absState = classifierAbsState bcc
-      regs = classifierFinalRegState bcc
-      blockEnd = classifierEndBlock bcc
-   in withArchConstraints (pctxArchInfo ctx) $
-        ParsedContents { parsedNonterm = toList (classifierStmts bcc)
-                       , parsedTerm  = ParsedCall regs Nothing
-                       , writtenCodeAddrs =
-                           filter (\a -> segoffAddr a /= blockEnd) $
-                             classifierWrittenAddrs bcc
-                       , intraJumpTargets = []
-                       , newFunctionAddrs = identifyCallTargets mem absState regs
-                       }
-
--- | Attempt to recognize tail call.
-noreturnCallClassifier :: BlockClassifier arch ids
-noreturnCallClassifier = classifierName "no return call" $ do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  -- Check for tail call when the calling convention seems to be satisfied.
-  withArchConstraints (pctxArchInfo ctx) $ do
-    let regs = classifierFinalRegState bcc
-    let ipVal = regs ^. boundValue ip_reg
-    -- Get memory address
-    ma <-
-      case valueAsMemAddr ipVal of
-        Nothing ->  fail $ printf "Noreturn target %s is not a valid address." (show ipVal)
-        Just a -> pure a
-    -- Get address
-    a <- case asSegmentOff (pctxMemory ctx) ma of
-           Nothing ->
-             fail $ printf "Noreturn target %s is not a segment offset." (show ipVal)
-           Just sa -> pure sa
-    -- Check function labeled noreturn
-    case Map.lookup a (pctxKnownFnEntries ctx) of
-      Nothing -> fail $ printf "Noreturn target %s is not a known function entry." (show a)
-      Just MayReturnFun -> fail $ printf "Return target %s labeled mayreturn." (show a)
-      Just NoReturnFun -> pure ()
-    -- Return no
-    pure $! noreturnCallParsedContents bcc
-
--- | Attempt to recognize tail call.
-tailCallClassifier :: BlockClassifier arch ids
-tailCallClassifier = classifierName "Tail call" $ do
-  bcc <- ask
-  let ctx = classifierParseContext bcc
-  let ainfo = pctxArchInfo ctx
-  -- Check for tail call when the calling convention seems to be satisfied.
-  withArchConstraints ainfo $ do
-
-    let spVal = classifierFinalRegState bcc ^. boundValue sp_reg
-    -- Check to see if the stack pointer points to an offset of the initial stack.
-    o <-
-      case transferValue (classifierAbsState bcc) spVal of
-        StackOffsetAbsVal _ o -> pure o
-        _ -> fail $ "Not a stack offset"
-    -- Stack stack is back to height when function was called.
-    unless (o == 0) $
-      fail "Expected stack height of 0"
-    -- Return address is pushed
-    unless (checkForReturnAddr ainfo (classifierFinalRegState bcc) (classifierAbsState bcc)) empty
-    pure $! noreturnCallParsedContents bcc
-
-useExternalTargets :: ( OrdF (ArchReg arch)
+useExternalTargets :: ( PC.OrdF (ArchReg arch)
                       , RegisterInfo (ArchReg arch)
                       )
                    => BlockClassifierContext arch ids
-                   -> Maybe [IntraJumpTarget arch]
+                   -> Maybe [Jmp.IntraJumpTarget arch]
 useExternalTargets bcc = do
   let ctx = classifierParseContext bcc
   let finalRegs = classifierFinalRegState bcc
@@ -1431,22 +485,35 @@ useExternalTargets bcc = do
   let nextInitJmpBounds = Jmp.postJumpBounds jmpBounds finalRegs
   return [ (tgt, blockState, nextInitJmpBounds) | tgt <- targets ]
 
+-- | This is a good default set of block classifiers
+--
+-- Block classifiers determine how the code discovery engine interprets the
+-- final instruction in each block. The individual classifiers are also exported
+-- so that architecture backends (or even end users) can provide their own
+-- classifiers.
+--
+-- See 'Data.Macaw.Discovery.Classifier' for the primitives necessary to define
+-- new classifiers (e.g., classifiers that can produce architecture-specific
+-- terminators).
+defaultClassifier :: BlockClassifier arch ids
+defaultClassifier = branchClassifier
+                <|> noreturnCallClassifier
+                <|> callClassifier
+                <|> returnClassifier
+                <|> directJumpClassifier
+                <|> jumpTableClassifier
+                <|> pltStubClassifier
+                <|> tailCallClassifier
+
 -- | This parses a block that ended with a fetch and execute instruction.
 parseFetchAndExecute :: forall arch ids
                      .  (RegisterInfo (ArchReg arch))
-                     => BlockClassifierContext arch ids
+                     => ArchitectureInfo arch
+                     -> BlockClassifierContext arch ids
                      -> [Stmt arch ids]
                      -> ParsedContents arch ids
-parseFetchAndExecute classCtx stmts = do
-  let cl = branchClassifier
-           <|> noreturnCallClassifier
-           <|> callClassifier
-           <|> returnClassifier
-           <|> directJumpClassifier
-           <|> jumpTableClassifier
-           <|> pltStubClassifier
-           <|> tailCallClassifier
-  case runReaderT cl classCtx of
+parseFetchAndExecute ainfo classCtx stmts = do
+  case runBlockClassifier (archClassifier ainfo) classCtx of
     ClassifySucceeded _ m -> m
     ClassifyFailed rsns ->
       ParsedContents { parsedNonterm = stmts
@@ -1491,7 +558,7 @@ parseBlock ctx initRegs b sz absBlockState blockBnds = do
             , classifierWrittenAddrs = writtenAddrs
             , classifierFinalRegState = finalRegs
             }
-      parseFetchAndExecute classCtx (blockStmts b)
+      parseFetchAndExecute ainfo classCtx (blockStmts b)
 
     -- Do nothing when this block ends in a translation error.
     TranslateError _ msg ->
@@ -1572,7 +639,7 @@ addBlock ctx src finfo pr s0 = do
                        , pblockTermStmt  = parsedTerm pc
                        }
   let pb' = dropUnusedCodeInParsedBlock ainfo pb
-  flip execStateT s0 $ unFunM $ do
+  flip CMS.execStateT s0 $ unFunM $ do
     id %= addFunBlock src pb'
     let insAddr :: FunctionExploreReason (ArchAddrWidth arch) -> ArchSegmentOff arch -> FunM arch s ids ()
         insAddr rsn a
@@ -1614,7 +681,7 @@ transfer addr s0 = do
 ------------------------------------------------------------------------
 -- Main loop
 
-mkFunState :: NonceGenerator (STS.ST s) ids
+mkFunState :: PN.NonceGenerator (STS.ST s) ids
            -> DiscoveryState arch
            -> FunctionExploreReason (ArchAddrWidth arch)
               -- ^ Reason to provide for why we are analyzing this function
@@ -1711,7 +778,7 @@ discoverFunction :: DiscoveryOptions
                 -> IncComp (DiscoveryEvent arch)
                            (DiscoveryState arch, Some (DiscoveryFunInfo arch))
 discoverFunction disOpts addr rsn s extraIntraTargets = STL.runST $ do
-  Some gen <- STL.strictToLazyST newSTNonceGenerator
+  Some gen <- STL.strictToLazyST PN.newSTNonceGenerator
   let fs0 = mkFunState gen s rsn addr extraIntraTargets
   analyzeBlocks disOpts s addr fs0
 
@@ -1772,13 +839,13 @@ exploreMemPointers :: [(ArchSegmentOff arch, ArchSegmentOff arch)]
                    -> DiscoveryState arch
                    -> DiscoveryState arch
 exploreMemPointers memWords info =
-  flip execState info $ do
-    forM_ memWords $ \(src, val) -> do
-      s <- get
+  flip CMS.execState info $ do
+    F.forM_ memWords $ \(src, val) -> do
+      s <- CMS.get
       let addFun = segmentFlags (segoffSegment src) `Perm.hasPerm` Perm.write
                 && shouldExploreFunction val s
       when addFun $ do
-        put $ markAddrAsFunction (CodePointerInMem src) val s
+        CMS.put $ markAddrAsFunction (CodePointerInMem src) val s
 
 -- | Expand an initial discovery state by exploring from a given set of function
 -- entry points.
@@ -1889,18 +956,18 @@ logDiscoveryEvent :: MemWidth (ArchAddrWidth arch)
 logDiscoveryEvent symMap p =
   case p of
     ReportAnalyzeFunction addr -> do
-      hPutStrLn stderr $ "Analyzing function: " ++ ppSymbol (Map.lookup addr symMap) addr
-      hFlush stderr
+      IO.hPutStrLn IO.stderr $ "Analyzing function: " ++ ppSymbol (Map.lookup addr symMap) addr
+      IO.hFlush IO.stderr
     ReportAnalyzeFunctionDone _ -> do
       pure ()
     ReportIdentifyFunction _ tgt rsn -> do
-      hPutStrLn stderr $ "  Identified candidate entry point "
+      IO.hPutStrLn IO.stderr $ "  Identified candidate entry point "
                        ++ ppSymbol (Map.lookup tgt symMap) tgt
                        ++ " " ++ ppFunReason rsn
-      hFlush stderr
+      IO.hFlush IO.stderr
     ReportAnalyzeBlock _ baddr -> do
-      hPutStrLn stderr $ "  Analyzing block: " ++ show baddr
-      hFlush stderr
+      IO.hPutStrLn IO.stderr $ "  Analyzing block: " ++ show baddr
+      IO.hFlush IO.stderr
 
 resolveFuns :: DiscoveryOptions
                -- ^ Options controlling discovery

--- a/base/src/Data/Macaw/Discovery/Classifier.hs
+++ b/base/src/Data/Macaw/Discovery/Classifier.hs
@@ -1,0 +1,399 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeApplications #-}
+-- | Definitions supporting block classification during code discovery
+--
+-- This module defines data types and helpers to build block control flow
+-- classifiers.  It comes with a pre-defined set that work well for most
+-- architectures.  A reasonable default classifier is provided for all supported
+-- architectures.  This infrastructure is available to enable derived tools to
+-- customize code discovery heuristics, and to enable architectures to provide
+-- architecture-specific rules.
+--
+-- Note that this is necessary for generating architecture-specific block
+-- terminators that can only be correctly injected based on analysis of values
+-- after abstract interpretation is applied to the rest of the code.
+module Data.Macaw.Discovery.Classifier (
+  -- * Utilities
+    isExecutableSegOff
+  , identifyConcreteAddresses
+  -- * Pre-defined classifiers
+  , branchClassifier
+  , callClassifier
+  , returnClassifier
+  , directJumpClassifier
+  , noreturnCallClassifier
+  , tailCallClassifier
+  ) where
+
+import           Control.Applicative ( Alternative(empty) )
+import           Control.Lens ( (^.), (&), (.~) )
+import           Control.Monad ( when, unless )
+import qualified Control.Monad.Reader as CMR
+import qualified Data.Foldable as F
+import qualified Data.Map.Strict as Map
+import           Data.Maybe ( maybeToList )
+import qualified Data.Set as Set
+import           Text.Printf (printf)
+
+import           Data.Macaw.AbsDomain.AbsState
+import qualified Data.Macaw.AbsDomain.JumpBounds as Jmp
+import qualified Data.Macaw.AbsDomain.Refine as Refine
+import           Data.Macaw.Architecture.Info as Info
+import           Data.Macaw.CFG
+import qualified Data.Macaw.Discovery.AbsEval as AbsEval
+import qualified Data.Macaw.Discovery.ParsedContents as Parsed
+import qualified Data.Macaw.Memory.Permissions as Perm
+import           Data.Macaw.Types
+
+------------------------------------------------------------------------
+-- Utilities
+
+isExecutableSegOff :: MemSegmentOff w -> Bool
+isExecutableSegOff sa =
+  segmentFlags (segoffSegment sa) `Perm.hasPerm` Perm.execute
+
+-- | Get code pointers out of a abstract value.
+identifyConcreteAddresses :: MemWidth w
+                          => Memory w
+                          -> AbsValue w (BVType w)
+                          -> [MemSegmentOff w]
+identifyConcreteAddresses mem (FinSet s) =
+  let ins o r =
+        case resolveAbsoluteAddr mem (fromInteger o) of
+          Just a | isExecutableSegOff a -> a : r
+          _ -> r
+   in foldr ins [] s
+identifyConcreteAddresses _ (CodePointers s _) = filter isExecutableSegOff $ Set.toList s
+identifyConcreteAddresses _mem StridedInterval{} = []
+identifyConcreteAddresses _mem _ = []
+
+
+-- | @normBool b q@ returns a pair where for each `NotApp` applied to @b@, we recursively
+-- take the argument to `NotApp` and the Boolean.
+--
+-- This is used to compare if one value is equal to or the syntactic
+-- complement of another value.
+normBool :: Value arch ids BoolType -> Bool -> (Value arch ids BoolType, Bool)
+normBool x b
+  | AssignedValue a <- x
+  , EvalApp (NotApp xn) <- assignRhs a =
+      normBool xn (not b)
+  | otherwise = (x,b)
+
+-- | This computes the abstract state for the start of a block for a
+-- given branch target.  It is used so that we can make use of the
+-- branch condition to simplify the abstract state.
+branchBlockState :: forall a ids t
+               .  ( Foldable t
+                  )
+               => Info.ArchitectureInfo a
+               -> AbsProcessorState (ArchReg a) ids
+               -> t (Stmt a ids)
+               -> RegState (ArchReg a) (Value a ids)
+                  -- ^  Register values
+               -> Value a ids BoolType
+                  -- ^ Branch condition
+               -> Bool
+                  -- ^ Flag indicating if branch is true or false.
+               -> AbsBlockState (ArchReg a)
+branchBlockState ainfo ps0 stmts regs c0 isTrue0 =
+  Info.withArchConstraints ainfo $
+    let (c,isTrue) = normBool c0 isTrue0
+        ps = Refine.refineProcState c isTrue ps0
+        mapReg :: ArchReg a tp -> Value a ids tp -> Value a ids tp
+        mapReg _r v
+          | AssignedValue a <- v
+          , EvalApp (Mux _ cv0 tv fv) <- assignRhs a
+          , (cv, b) <- normBool cv0 isTrue
+          , cv == c =
+              if b then tv else fv
+          | otherwise =
+              v
+        refinedRegs = mapRegsWith mapReg regs
+     in finalAbsBlockState (F.foldl' (AbsEval.absEvalStmt ainfo) ps stmts) refinedRegs
+
+classifyDirectJump :: RegisterInfo (ArchReg arch)
+                   => ParseContext arch ids
+                   -> String
+                   -> Value arch ids (BVType (ArchAddrWidth arch))
+                   -> BlockClassifierM arch ids (MemSegmentOff (ArchAddrWidth arch))
+classifyDirectJump ctx nm v = do
+  ma <- case valueAsMemAddr v of
+          Nothing ->  fail $ nm ++ " value " ++ show v ++ " is not a valid address."
+          Just a -> pure a
+  a <- case asSegmentOff (pctxMemory ctx) ma of
+         Nothing ->
+           fail $ nm ++ " value " ++ show v ++ " is not a segment offset in " ++ show (pctxMemory ctx) ++ "."
+         Just sa -> pure sa
+  when (not (segmentFlags (segoffSegment a) `Perm.hasPerm` Perm.execute)) $ do
+    fail $ nm ++ " value " ++ show a ++ " is not executable."
+  when (a == pctxFunAddr ctx) $ do
+    fail $ nm ++ " value " ++ show a ++ " refers to function start."
+  when (a `Map.member` pctxKnownFnEntries ctx) $ do
+    fail $ nm ++ " value " ++ show a ++ " is a known function entry."
+  pure a
+
+-- | The classifier for conditional and unconditional branches
+--
+-- Note that this classifier can convert a conditional branch to an
+-- unconditional branch if (and only if) the condition is syntactically true or
+-- false after constant propagation. It never attempts sophisticated path
+-- trimming.
+branchClassifier :: BlockClassifier arch ids
+branchClassifier = classifierName "Branch" $ do
+  bcc <- CMR.ask
+  let ctx = classifierParseContext bcc
+  let finalRegs = classifierFinalRegState bcc
+  let writtenAddrs = classifierWrittenAddrs bcc
+  let absState = classifierAbsState bcc
+  let stmts = classifierStmts bcc
+  let ainfo = pctxArchInfo ctx
+  Info.withArchConstraints ainfo $ do
+    -- The block ends with a Mux, so we turn this into a `ParsedBranch` statement.
+    let ipVal = finalRegs^.boundValue ip_reg
+    (c,t,f) <- case valueAsApp ipVal of
+                 Just (Mux _ c t f) -> pure (c,t,f)
+                 _ -> fail $ "IP is not an mux:\n"
+                          ++ show (ppValueAssignments ipVal)
+    trueTgtAddr  <- classifyDirectJump ctx "True branch"  t
+    falseTgtAddr <- classifyDirectJump ctx "False branch" f
+
+    let trueRegs  = finalRegs & boundValue ip_reg .~ t
+    let falseRegs = finalRegs & boundValue ip_reg .~ f
+
+    let trueAbsState  = branchBlockState ainfo absState stmts trueRegs c True
+    let falseAbsState = branchBlockState ainfo absState stmts falseRegs c False
+    let jmpBounds = classifierJumpBounds bcc
+    case Jmp.postBranchBounds jmpBounds finalRegs c of
+      Jmp.BothFeasibleBranch trueJmpState falseJmpState -> do
+        pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList stmts
+                                  , Parsed.parsedTerm  =
+                                    Parsed.ParsedBranch finalRegs c trueTgtAddr falseTgtAddr
+                                  , Parsed.writtenCodeAddrs = writtenAddrs
+                                  , Parsed.intraJumpTargets =
+                                    [ (trueTgtAddr,  trueAbsState,  trueJmpState)
+                                    , (falseTgtAddr, falseAbsState, falseJmpState)
+                                    ]
+                                  , Parsed.newFunctionAddrs = []
+                                  }
+      -- The false branch is impossible.
+      Jmp.TrueFeasibleBranch trueJmpState -> do
+        pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList stmts
+                                  , Parsed.parsedTerm  = Parsed.ParsedJump finalRegs trueTgtAddr
+                                  , Parsed.writtenCodeAddrs = writtenAddrs
+                                  , Parsed.intraJumpTargets =
+                                    [(trueTgtAddr, trueAbsState, trueJmpState)]
+                                  , Parsed.newFunctionAddrs = []
+                                  }
+      -- The true branch is impossible.
+      Jmp.FalseFeasibleBranch falseJmpState -> do
+        pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList stmts
+                                  , Parsed.parsedTerm  = Parsed.ParsedJump finalRegs falseTgtAddr
+                                  , Parsed.writtenCodeAddrs = writtenAddrs
+                                  , Parsed.intraJumpTargets =
+                                    [(falseTgtAddr, falseAbsState, falseJmpState)]
+                                  , Parsed.newFunctionAddrs = []
+                              }
+      -- Both branches were deemed impossible
+      Jmp.InfeasibleBranch -> do
+        fail $ "Branch targets are both unreachable."
+
+-- | Identify new potential function entry points by looking at IP.
+identifyCallTargets :: forall arch ids
+                    .  (RegisterInfo (ArchReg arch))
+                    => Memory (ArchAddrWidth arch)
+                    -> AbsProcessorState (ArchReg arch) ids
+                       -- ^ Abstract processor state just before call.
+                    -> RegState (ArchReg arch) (Value arch ids)
+                    -> [ArchSegmentOff arch]
+identifyCallTargets mem absState regs = do
+  -- Code pointers from abstract domains.
+  let def = identifyConcreteAddresses mem $ transferValue absState (regs^.boundValue ip_reg)
+  case regs^.boundValue ip_reg of
+    BVValue _ x ->
+      maybeToList $ resolveAbsoluteAddr mem (fromInteger x)
+    RelocatableValue _ a ->
+      maybeToList $ asSegmentOff mem a
+    SymbolValue{} -> []
+    AssignedValue a ->
+      case assignRhs a of
+        -- See if we can get a value out of a concrete memory read.
+        ReadMem addr (BVMemRepr _ end)
+          | Just laddr <- valueAsMemAddr addr
+          , Right val <- readSegmentOff mem end laddr ->
+            val : def
+        _ -> def
+    Initial _ -> def
+
+-- |  Use the architecture-specific callback to check if last statement was a call.
+--
+-- Note that in some cases the call is known not to return, and thus this code
+-- will never jump to the return value; in that case, the
+-- 'noreturnCallClassifier' should fire. As such, 'callClassifier' should always
+-- be attempted *after* 'noreturnCallClassifier'.
+callClassifier :: BlockClassifier arch ids
+callClassifier = do
+  bcc <- CMR.ask
+  let ctx = classifierParseContext bcc
+  let finalRegs = classifierFinalRegState bcc
+  let ainfo = pctxArchInfo ctx
+  let mem = pctxMemory ctx
+  ret <- case Info.identifyCall ainfo mem (classifierStmts bcc) finalRegs of
+           Just (_prev_stmts, ret) -> pure ret
+           Nothing -> fail $ "Call classifer failed."
+  Info.withArchConstraints ainfo $ do
+    pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList (classifierStmts bcc)
+                              , Parsed.parsedTerm  = Parsed.ParsedCall finalRegs (Just ret)
+                              -- The return address may be written to
+                              -- stack, but is highly unlikely to be
+                              -- a function entry point.
+                              , Parsed.writtenCodeAddrs = filter (\a -> a /= ret) (classifierWrittenAddrs bcc)
+                              --Include return target
+                              , Parsed.intraJumpTargets =
+                                [( ret
+                                 , Info.postCallAbsState ainfo (classifierAbsState bcc) finalRegs ret
+                                 , Jmp.postCallBounds (Info.archCallParams ainfo) (classifierJumpBounds bcc) finalRegs
+                                 )]
+                              -- Use the abstract domain to look for new code pointers for the current IP.
+                              , Parsed.newFunctionAddrs = identifyCallTargets mem (classifierAbsState bcc) finalRegs
+                              }
+
+-- | Check this block ends with a return as identified by the
+-- architecture-specific processing.  Basic return identification
+-- can be performed by detecting when the Instruction Pointer
+-- (ip_reg) contains the 'ReturnAddr' symbolic value (initially
+-- placed on the top of the stack or in the Link Register by the
+-- architecture-specific state initializer).  However, some
+-- architectures perform expression evaluations on this value before
+-- loading the IP (e.g. ARM will clear the low bit in T32 mode or
+-- the low 2 bits in A32 mode), so the actual detection process is
+-- deferred to architecture-specific functionality.
+returnClassifier :: BlockClassifier arch ids
+returnClassifier = classifierName "Return" $ do
+  bcc <- CMR.ask
+  let ainfo = pctxArchInfo (classifierParseContext bcc)
+  Info.withArchConstraints ainfo $ do
+    Just prevStmts <-
+      pure $ Info.identifyReturn ainfo
+                            (classifierStmts bcc)
+                            (classifierFinalRegState bcc)
+                            (classifierAbsState bcc)
+    pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList prevStmts
+                              , Parsed.parsedTerm = Parsed.ParsedReturn (classifierFinalRegState bcc)
+                              , Parsed.writtenCodeAddrs = classifierWrittenAddrs bcc
+                              , Parsed.intraJumpTargets = []
+                              , Parsed.newFunctionAddrs = []
+                              }
+
+-- | Classifies jumps to concrete addresses as unconditional jumps.  Note that
+-- this logic is substantially similar to the 'callClassifier'; as such, this
+-- classifier should always be applied *after* the 'callClassifier'.
+directJumpClassifier :: BlockClassifier arch ids
+directJumpClassifier = classifierName "Jump" $ do
+  bcc <- CMR.ask
+  let ctx = classifierParseContext bcc
+  let ainfo = pctxArchInfo ctx
+  Info.withArchConstraints ainfo $ do
+
+    tgtMSeg <- classifyDirectJump ctx "Jump" (classifierFinalRegState bcc ^. boundValue ip_reg)
+
+    let abst = finalAbsBlockState (classifierAbsState bcc) (classifierFinalRegState bcc)
+    let abst' = abst & setAbsIP tgtMSeg
+    let tgtBnds = Jmp.postJumpBounds (classifierJumpBounds bcc) (classifierFinalRegState bcc)
+    pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList (classifierStmts bcc)
+                              , Parsed.parsedTerm  = Parsed.ParsedJump (classifierFinalRegState bcc) tgtMSeg
+                              , Parsed.writtenCodeAddrs = classifierWrittenAddrs bcc
+                              , Parsed.intraJumpTargets = [(tgtMSeg, abst', tgtBnds)]
+                              , Parsed.newFunctionAddrs = []
+                              }
+
+classifierEndBlock :: BlockClassifierContext arch ids
+                   -> MemAddr (ArchAddrWidth arch)
+classifierEndBlock ctx = Info.withArchConstraints (pctxArchInfo (classifierParseContext ctx)) $
+  let blockStart = segoffAddr (pctxAddr (classifierParseContext ctx))
+   in incAddr (toInteger (classifierBlockSize ctx)) blockStart
+
+noreturnCallParsedContents :: BlockClassifierContext arch ids -> Parsed.ParsedContents arch ids
+noreturnCallParsedContents bcc =
+  let ctx  = classifierParseContext bcc
+      mem  = pctxMemory ctx
+      absState = classifierAbsState bcc
+      regs = classifierFinalRegState bcc
+      blockEnd = classifierEndBlock bcc
+   in Info.withArchConstraints (pctxArchInfo ctx) $
+        Parsed.ParsedContents { Parsed.parsedNonterm = F.toList (classifierStmts bcc)
+                           , Parsed.parsedTerm  = Parsed.ParsedCall regs Nothing
+                           , Parsed.writtenCodeAddrs =
+                             filter (\a -> segoffAddr a /= blockEnd) $
+                             classifierWrittenAddrs bcc
+                           , Parsed.intraJumpTargets = []
+                           , Parsed.newFunctionAddrs = identifyCallTargets mem absState regs
+                           }
+
+-- | Attempt to recognize a call to a function that is known to not
+-- return. These are effectively tail calls, even if the compiler did not
+-- obviously generate a tail call instruction sequence.
+--
+-- This classifier is important because compilers often place garbage
+-- instructions (for alignment, or possibly the next function) after calls to
+-- no-return functions. Without knowledge of no-return functions, macaw would
+-- otherwise think that the callee could return to the garbage instructions,
+-- causing later classification failures.
+--
+-- This functionality depends on a set of known non-return functions are
+-- specified as an input to the code discovery process (see 'pctxKnownFnEntries').
+--
+-- Note that this classifier should always be run before the 'callClassifier'.
+noreturnCallClassifier :: BlockClassifier arch ids
+noreturnCallClassifier = classifierName "no return call" $ do
+  bcc <- CMR.ask
+  let ctx = classifierParseContext bcc
+  -- Check for tail call when the calling convention seems to be satisfied.
+  Info.withArchConstraints (pctxArchInfo ctx) $ do
+    let regs = classifierFinalRegState bcc
+    let ipVal = regs ^. boundValue ip_reg
+    -- Get memory address
+    ma <-
+      case valueAsMemAddr ipVal of
+        Nothing ->  fail $ printf "Noreturn target %s is not a valid address." (show ipVal)
+        Just a -> pure a
+    -- Get address
+    a <- case asSegmentOff (pctxMemory ctx) ma of
+           Nothing ->
+             fail $ printf "Noreturn target %s is not a segment offset." (show ipVal)
+           Just sa -> pure sa
+    -- Check function labeled noreturn
+    case Map.lookup a (pctxKnownFnEntries ctx) of
+      Nothing -> fail $ printf "Noreturn target %s is not a known function entry." (show a)
+      Just MayReturnFun -> fail $ printf "Return target %s labeled mayreturn." (show a)
+      Just NoReturnFun -> pure ()
+    -- Return no
+    pure $! noreturnCallParsedContents bcc
+
+-- | Attempt to recognize tail call
+--
+-- The current heuristic is that the target looks like a call, except the stack
+-- height in the caller is 0.
+tailCallClassifier :: BlockClassifier arch ids
+tailCallClassifier = classifierName "Tail call" $ do
+  bcc <- CMR.ask
+  let ctx = classifierParseContext bcc
+  let ainfo = pctxArchInfo ctx
+  -- Check for tail call when the calling convention seems to be satisfied.
+  Info.withArchConstraints ainfo $ do
+
+    let spVal = classifierFinalRegState bcc ^. boundValue sp_reg
+    -- Check to see if the stack pointer points to an offset of the initial stack.
+    o <-
+      case transferValue (classifierAbsState bcc) spVal of
+        StackOffsetAbsVal _ o -> pure o
+        _ -> fail $ "Not a stack offset"
+    -- Stack stack is back to height when function was called.
+    unless (o == 0) $
+      fail "Expected stack height of 0"
+    -- Return address is pushed
+    unless (Info.checkForReturnAddr ainfo (classifierFinalRegState bcc) (classifierAbsState bcc)) empty
+    pure $! noreturnCallParsedContents bcc

--- a/base/src/Data/Macaw/Discovery/Classifier/JumpTable.hs
+++ b/base/src/Data/Macaw/Discovery/Classifier/JumpTable.hs
@@ -1,0 +1,385 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+module Data.Macaw.Discovery.Classifier.JumpTable (
+  jumpTableClassifier
+  ) where
+
+import           Control.Applicative ( Alternative((<|>)) )
+import           Control.Lens ( (&), (^.) )
+import           Control.Monad ( when, unless )
+import qualified Control.Monad.Reader as CMR
+import qualified Data.ByteString as BS
+import qualified Data.Foldable as F
+import           Data.Int ( Int32, Int64 )
+import qualified Data.Map.Strict as Map
+import           Data.Parameterized.Classes
+import           Data.Parameterized.NatRepr
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.Traversable as T
+import qualified Data.Vector as V
+import           Data.Word ( Word64 )
+import           Numeric ( showHex )
+import           Numeric.Natural ( Natural )
+import qualified Prettyprinter as PP
+
+import qualified Data.Macaw.Architecture.Info as Info
+import           Data.Macaw.AbsDomain.AbsState
+import qualified Data.Macaw.AbsDomain.JumpBounds as Jmp
+import qualified Data.Macaw.AbsDomain.StridedInterval as SI
+import           Data.Macaw.CFG
+import qualified Data.Macaw.Discovery.ParsedContents as Parsed
+import qualified Data.Macaw.Memory.Permissions as Perm
+import           Data.Macaw.Types
+
+--------------------------------------------------------------------------------
+-- Jump table recognition
+
+-- | `extendDyn ext end bs` parses the bytestring using the extension
+-- and endianness information, and returns the extended value.
+extendDyn :: Parsed.Extension w -> Endianness -> BS.ByteString -> Integer
+extendDyn (Parsed.Extension False Addr32) end bs  = toInteger (bsWord32 end bs)
+extendDyn (Parsed.Extension False Addr64) end bs  = toInteger (bsWord64 end bs)
+extendDyn (Parsed.Extension True  Addr32) end bs = toInteger (fromIntegral (bsWord32 end bs) :: Int32)
+extendDyn (Parsed.Extension True  Addr64) end bs = toInteger (fromIntegral (bsWord64 end bs) :: Int64)
+
+-- This function resolves jump table entries.
+-- It is a recursive function that has an index into the jump table.
+-- If the current index can be interpreted as a intra-procedural jump,
+-- then it will add that to the current procedure.
+-- This returns the last address read.
+resolveRelativeJumps :: forall arch w
+                        .  ( MemWidth (ArchAddrWidth arch)
+                        , IPAlignment arch
+                        , RegisterInfo (ArchReg arch)
+                        )
+                     => Memory (ArchAddrWidth arch)
+                     -> ArchSegmentOff arch
+                     -> Parsed.BoundedMemArray arch (BVType w)
+                     -> Parsed.Extension w
+                     -> Either String (V.Vector (ArchSegmentOff arch))
+resolveRelativeJumps mem base arrayRead ext = do
+  let slices = Parsed.arSlices arrayRead
+  let BVMemRepr _ endianness = Parsed.arEltType arrayRead
+  T.forM slices $ \l -> do
+    bs <- case l of
+            [ByteRegion bs] -> Right bs
+            _ -> Left $ "Could not recognize slice: " <> show l
+    let tgtAddr = segoffAddr base & incAddr (extendDyn ext endianness bs)
+
+    let brRepr = unwords [ showHex w "" | w <- BS.unpack bs ]
+
+    tgt <- case asSegmentOff mem (toIPAligned @arch tgtAddr) of
+             Just tgt -> Right tgt
+             _ -> Left $ "Could not resolve " <> show (ext, endianness, base, brRepr)
+
+    unless (Perm.isExecutable (segmentFlags (segoffSegment tgt))) $ do
+      Left "Address is not executable."
+
+    Right tgt
+
+sliceMemContents'
+  :: MemWidth w
+  => Int -- ^ Number of bytes in each slice.
+  -> [[MemChunk w]] -- ^ Previous slices
+  -> Integer -- ^ Number of slices to return
+  -> [MemChunk w] -- ^ Ranges to process next
+  -> Either (SplitError w) ([[MemChunk w]],[MemChunk w])
+sliceMemContents' stride prev c next
+  | c <= 0 = pure (reverse prev, next)
+  | otherwise =
+    case splitMemChunks next stride of
+      Left e -> Left e
+      Right (this, rest) -> sliceMemContents' stride (this:prev) (c-1) rest
+
+-- | @sliceMemContents stride cnt contents@ splits contents up into @cnt@
+-- memory regions each with size @stride@.
+sliceMemContents
+  :: MemWidth w
+  => Int -- ^ Number of bytes in each slice.
+  -> Integer -- ^ Number of slices to return
+  -> [MemChunk w] -- ^ Ranges to process next
+  -> Either (SplitError w) ([[MemChunk w]],[MemChunk w])
+sliceMemContents stride c next = sliceMemContents' stride [] c next
+
+-------------------------------------------------------------------------------
+-- BoundedMemArray recognition
+
+absValueAsSegmentOff
+  :: forall w
+  .  Memory w
+  -> AbsValue w (BVType  w)
+  -> Maybe (MemSegmentOff w)
+absValueAsSegmentOff mem av = case av of
+  FinSet s | Set.size s == 1 -> resolveAbsoluteIntegerAddr (shead s)
+  CodePointers s False | Set.size s == 1 -> Just (shead s)
+  CodePointers s True  | Set.size s == 0 -> resolveAbsoluteIntegerAddr 0
+  StridedInterval si -> SI.isSingleton si >>= resolveAbsoluteIntegerAddr
+  _ -> Nothing
+  where
+  shead :: Set a -> a
+  shead = Set.findMin
+
+  resolveAbsoluteIntegerAddr :: Integer -> Maybe (MemSegmentOff w)
+  resolveAbsoluteIntegerAddr = resolveAbsoluteAddr mem . addrWidthClass (memAddrWidth mem) fromInteger
+
+-- | This attempts to interpret a value as a memory segment offset
+-- using the memory and abstract interpretation of value.
+valueAsSegmentOffWithTransfer
+  :: forall arch ids
+  .  RegisterInfo (ArchReg arch)
+  => Memory (ArchAddrWidth arch)
+  -> AbsProcessorState (ArchReg arch) ids
+  -> BVValue arch ids (ArchAddrWidth arch)
+  -> Maybe (ArchSegmentOff arch)
+valueAsSegmentOffWithTransfer mem aps base
+  =   valueAsSegmentOff mem base
+  <|> absValueAsSegmentOff mem (transferValue aps base)
+
+-- | This attempts to pattern match a value as a memory address plus a value.
+valueAsMemOffset
+  :: RegisterInfo (ArchReg arch)
+  => Memory (ArchAddrWidth arch)
+  -> AbsProcessorState (ArchReg arch) ids
+  -> ArchAddrValue arch ids
+  -> Maybe (ArchSegmentOff arch, ArchAddrValue arch ids)
+valueAsMemOffset mem aps v
+  | Just (BVAdd _ base offset) <- valueAsApp v
+  , Just ptr <- valueAsSegmentOffWithTransfer mem aps base
+  = Just (ptr, offset)
+
+  -- and with the other argument order
+  | Just (BVAdd _ offset base) <- valueAsApp v
+  , Just ptr <- valueAsSegmentOffWithTransfer mem aps base
+  = Just (ptr, offset)
+
+  | otherwise = Nothing
+
+-- This function resolves jump table entries.
+-- It is a recursive function that has an index into the jump table.
+-- If the current index can be interpreted as a intra-procedural jump,
+-- then it will add that to the current procedure.
+-- This returns the last address read.
+resolveAsAddr :: forall w
+              .  Memory w
+              -> Endianness
+              -> [MemChunk w]
+              -> Maybe (MemAddr w)
+resolveAsAddr mem endianness l = addrWidthClass (memAddrWidth mem) $
+  case l of
+    [ByteRegion bs] ->
+      case addrRead endianness bs of
+        Just a -> pure $! absoluteAddr a
+        Nothing -> error $ "internal: resolveAsAddr given short chunk list."
+    [RelocationRegion r] -> do
+        when (relocationIsRel r) $ Nothing
+        case relocationSym r of
+          SymbolRelocation{} -> Nothing
+          SectionIdentifier idx -> do
+            addr <- Map.lookup idx (memSectionIndexMap mem)
+            pure $! segoffAddr addr & incAddr (toInteger (relocationOffset r))
+          SegmentBaseAddr idx -> do
+            seg <- Map.lookup idx (memSegmentIndexMap mem)
+            pure $! segmentOffAddr seg (relocationOffset r)
+          LoadBaseAddr -> do
+            memBaseAddr mem
+    _ -> Nothing
+
+-- | Just like Some (BVValue arch ids), but doesn't run into trouble with
+-- partially applying the BVValue type synonym.
+data SomeExt arch ids = forall m . SomeExt !(BVValue arch ids m) !(Parsed.Extension m)
+
+matchAddr :: NatRepr w -> Maybe (AddrWidthRepr w)
+matchAddr w
+  | Just Refl <- testEquality w n32 = Just Addr32
+  | Just Refl <- testEquality w n64 = Just Addr64
+  | otherwise = Nothing
+
+-- | @matchExtension x@ matches in @x@ has the form @uext y w@ or @sext y w@ and returns
+-- a description about the extension as well as the pattern @y@.
+matchExtension :: forall arch ids
+               .  ( MemWidth (ArchAddrWidth arch)
+                  , HasRepr (ArchReg arch) TypeRepr)
+               => ArchAddrValue arch ids
+               -> SomeExt arch ids
+matchExtension val =
+  case valueAsApp val of
+    Just (SExt val' _w) | Just repr <- matchAddr (typeWidth val') -> SomeExt val' (Parsed.Extension True  repr)
+    Just (UExt val' _w) | Just repr <- matchAddr (typeWidth val') -> SomeExt val' (Parsed.Extension False repr)
+    _ -> SomeExt val (Parsed.Extension False (addrWidthRepr @(ArchAddrWidth arch) undefined))
+
+-- | Contains information about jump table layout, addresses and index
+-- in a recognized jump table.
+type JumpTableClassifierResult arch ids =
+   (Parsed.JumpTableLayout arch, V.Vector (ArchSegmentOff arch), ArchAddrValue arch ids)
+
+type JumpTableClassifier arch ids s =
+  Info.BlockClassifierM arch ids (JumpTableClassifierResult arch ids)
+
+-- | This operation extracts chunks of memory for a jump table.
+extractJumpTableSlices :: ArchConstraints arch
+                       => Jmp.IntraJumpBounds arch ids
+                       -- ^ Bounds for jump table
+                       -> MemSegmentOff (ArchAddrWidth arch) -- ^ Base address
+                       -> Natural -- ^ Stride
+                       -> BVValue arch ids idxWidth
+                       -> MemRepr tp -- ^ Type of values
+                       -> Info.Classifier (V.Vector [MemChunk (ArchAddrWidth arch)])
+extractJumpTableSlices jmpBounds base stride ixVal tp = do
+  cnt <-
+    case Jmp.unsignedUpperBound jmpBounds ixVal of
+      Nothing -> fail $ "Upper bounds failed:\n"
+                      ++ show (ppValueAssignments ixVal) ++ "\n"
+                      ++ show (PP.pretty jmpBounds)
+      Just bnd -> do
+        let cnt = toInteger (bnd+1)
+        -- Check array actually fits in memory.
+        when (cnt * toInteger stride > segoffBytesLeft base) $ do
+          fail "Size is too large."
+        pure cnt
+
+  -- Get memory contents after base
+  Right contents <- pure $ segoffContentsAfter base
+  -- Break up contents into a list of slices each with size stide
+  Right (strideSlices,_) <- pure $ sliceMemContents (fromIntegral stride) cnt contents
+  -- Get memory slices
+  Right slices <-
+    pure $ traverse (\s -> fst <$> splitMemChunks s (fromIntegral (memReprBytes tp)))
+                    (V.fromList strideSlices)
+  pure slices
+
+-- | @matchBoundedMemArray mem aps bnds val@ checks to try to interpret
+-- @val@ as a memory read where
+--
+-- * the address read has the form @base + stride * ixVal@,
+-- * @base@ is a valid `MemSegmentOff`,
+-- * @stride@ is a natural number and,
+-- * @ixVal@ is a arbitrary value.
+matchBoundedMemArray
+  :: ArchConstraints arch
+  => Memory (ArchAddrWidth arch)
+  -> AbsProcessorState (ArchReg arch) ids
+  -> Jmp.IntraJumpBounds arch ids
+     -- ^ Bounds for jump table
+  -> Value arch ids tp  -- ^ Value to interpret
+  -> Info.Classifier (Parsed.BoundedMemArray arch tp, ArchAddrValue arch ids)
+matchBoundedMemArray mem aps jmpBounds val = do
+  AssignedValue (Assignment _ (ReadMem addr tp)) <- pure val
+  Just (base, offset) <- pure $ valueAsMemOffset mem aps addr
+  Just (stride, ixVal) <- pure $ valueAsStaticMultiplication offset
+   -- Check stride covers at least number of bytes read.
+  when (memReprBytes tp > stride) $ do
+    fail "Stride does not cover size of relocation."
+  -- Convert stride to word64 (must be lossless due to as memory is at most 64-bits)
+  let stridew :: Word64
+      stridew = fromIntegral stride
+  -- Take the given number of bytes out of each slices
+  slices <- extractJumpTableSlices jmpBounds base stride ixVal tp
+
+  let r = Parsed.BoundedMemArray
+          { Parsed.arBase     = base
+          , Parsed.arStride   = stridew
+          , Parsed.arEltType  = tp
+          , Parsed.arSlices   = slices
+          }
+  pure  (r, ixVal)
+
+-- | @matchAbsoluteJumpTable@ tries to match the control flow transfer
+-- as a jump table where the addresses in the jump table are absolute
+-- memory addresses.
+matchAbsoluteJumpTable
+  :: forall arch ids s
+  .  ArchConstraints arch
+  => JumpTableClassifier arch ids s
+matchAbsoluteJumpTable = Info.classifierName "Absolute jump table" $ do
+  bcc <- CMR.ask
+  let mem = Info.pctxMemory (Info.classifierParseContext bcc)
+  let aps = Info.classifierAbsState bcc
+  let jmpBounds = Info.classifierJumpBounds bcc
+  -- Get IP value to interpret as a jump table index.
+  let ip = Info.classifierFinalRegState bcc^.curIP
+  (arrayRead, idx) <- Info.liftClassifier $ matchBoundedMemArray mem aps jmpBounds ip
+  unless (Parsed.isReadOnlyBoundedMemArray arrayRead) $ do
+    fail "Bounded mem array is not read only."
+  endianness <-
+    case Parsed.arEltType arrayRead of
+      BVMemRepr _arByteCount e -> pure e
+  let go :: Int
+         -> [MemChunk (ArchAddrWidth arch)]
+         -> Info.Classifier (MemSegmentOff (ArchAddrWidth arch))
+      go entryIndex contents = do
+        addr <- case resolveAsAddr mem endianness contents of
+                  Just a -> pure a
+                  Nothing -> fail "Could not resolve jump table contents as absolute address."
+        tgt <- case asSegmentOff mem (toIPAligned @arch addr) of
+                 Just t -> pure t
+                 Nothing ->
+                   fail $
+                     "Could not resolve jump table entry " ++ show entryIndex
+                     ++ " value " ++ show addr ++ " as segment offset.\n" ++ show mem
+        unless (Perm.isExecutable (segmentFlags (segoffSegment tgt))) $
+          fail $ "Jump table contents non-executable."
+        pure tgt
+  tbl <- Info.liftClassifier $ V.zipWithM go (V.generate (V.length (Parsed.arSlices arrayRead)) id) (Parsed.arSlices arrayRead)
+  pure (Parsed.AbsoluteJumpTable arrayRead, tbl, idx)
+
+-- | @matchAbsoluteJumpTable@ tries to match the control flow transfer
+-- as a jump table where the addresses in the jump table are IP relative jumps.
+matchRelativeJumpTable
+  :: forall arch ids s
+  .  ArchConstraints arch
+  => JumpTableClassifier arch ids s
+matchRelativeJumpTable = Info.classifierName "Relative jump table" $ do
+  bcc <- CMR.ask
+  let mem = Info.pctxMemory (Info.classifierParseContext bcc)
+  let aps = Info.classifierAbsState bcc
+  let jmpBounds = Info.classifierJumpBounds bcc
+  -- Get IP value to interpret as a jump table index.
+  let ip = Info.classifierFinalRegState bcc^.curIP
+
+  -- gcc-style PIC jump tables on x86 use, roughly,
+  --     ip = jmptbl + jmptbl[index]
+  -- where jmptbl is a pointer to the lookup table.
+  Just unalignedIP <- pure $ fromIPAligned ip
+  (tgtBase, tgtOffset) <-
+    case valueAsMemOffset mem aps unalignedIP of
+      Just p -> pure p
+      Nothing -> fail $ "Unaligned IP not a mem offset: " <> show unalignedIP
+  SomeExt shortOffset ext <- pure $ matchExtension tgtOffset
+  (arrayRead, idx) <- Info.liftClassifier $ matchBoundedMemArray mem aps jmpBounds shortOffset
+  unless (Parsed.isReadOnlyBoundedMemArray arrayRead) $ do
+    fail $ "Jump table memory array must be read only."
+  tbl <- case resolveRelativeJumps mem tgtBase arrayRead ext of
+           Left msg -> fail msg
+           Right tbl -> pure tbl
+  pure (Parsed.RelativeJumpTable tgtBase arrayRead ext, tbl, idx)
+
+-- | A classifier for jump tables
+--
+-- This classifier employs a number of heuristics, but is of course incomplete
+jumpTableClassifier :: forall arch ids . Info.BlockClassifier arch ids
+jumpTableClassifier = Info.classifierName "Jump table" $ do
+  bcc <- CMR.ask
+  let ctx = Info.classifierParseContext bcc
+  let ainfo = Info.pctxArchInfo ctx
+  let jmpBounds = Info.classifierJumpBounds bcc
+  Info.withArchConstraints ainfo $ do
+    let jumpTableClassifiers
+          =   matchAbsoluteJumpTable
+          <|> matchRelativeJumpTable
+    (layout, entries, jumpIndex) <- jumpTableClassifiers
+
+    let abst :: AbsBlockState (ArchReg arch)
+        abst = finalAbsBlockState (Info.classifierAbsState bcc) (Info.classifierFinalRegState bcc)
+    let nextBnds = Jmp.postJumpBounds jmpBounds (Info.classifierFinalRegState bcc)
+    let term = Parsed.ParsedLookupTable layout (Info.classifierFinalRegState bcc) jumpIndex entries
+    pure $ seq abst $
+      Parsed.ParsedContents { Parsed.parsedNonterm = F.toList (Info.classifierStmts bcc)
+                         , Parsed.parsedTerm = term
+                         , Parsed.writtenCodeAddrs = Info.classifierWrittenAddrs bcc
+                         , Parsed.intraJumpTargets =
+                           [ (tgtAddr, abst & setAbsIP tgtAddr, nextBnds)
+                           | tgtAddr <- V.toList entries
+                           ]
+                         , Parsed.newFunctionAddrs = []
+                         }

--- a/base/src/Data/Macaw/Discovery/Classifier/PLT.hs
+++ b/base/src/Data/Macaw/Discovery/Classifier/PLT.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Data.Macaw.Discovery.Classifier.PLT (
+  pltStubClassifier
+  ) where
+
+import           Control.Lens ( (^.) )
+import           Control.Monad ( when, unless )
+import qualified Control.Monad.Reader as CMR
+import qualified Data.Foldable as F
+import           Data.Monoid ( Any(..) )
+import           Data.Parameterized.Classes
+import qualified Data.Parameterized.Map as MapF
+import           Data.Parameterized.Some
+import           Data.Parameterized.TraversableF
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
+
+import qualified Data.Macaw.Architecture.Info as Info
+import           Data.Macaw.CFG
+import qualified Data.Macaw.Discovery.ParsedContents as Parsed
+
+-- | @stripPLTRead assignId prev rest@ looks for a read of @assignId@
+-- from the end of @prev@, and if it finds it returns the
+-- concatenation of the instruction before the read in @prev@ and
+-- @rest@.
+--
+-- The read may appear before comment and @instructionStart@
+-- instructions, but otherwise must be at the end of the instructions
+-- in @prev@.
+stripPLTRead :: forall arch ids tp
+               . ArchConstraints arch
+              => AssignId ids tp -- ^ Identifier of write to remove
+              -> Seq (Stmt arch ids)
+              -> Seq (Stmt arch ids)
+              -> Maybe (Seq (Stmt arch ids))
+stripPLTRead readId next rest =
+  case Seq.viewr next of
+    Seq.EmptyR -> Nothing
+    prev Seq.:> lastStmt -> do
+      let cont = stripPLTRead readId prev (lastStmt Seq.<| rest)
+      case lastStmt of
+        AssignStmt (Assignment stmtId rhs)
+          | Just Refl <- testEquality readId stmtId ->
+              Just (prev Seq.>< fmap (dropRefsTo stmtId) rest)
+            -- Fail if the read to delete is used in later computations
+          | Set.member (Some readId) (foldMapFC refsInValue rhs) ->
+              Nothing
+          | otherwise ->
+            case rhs of
+              EvalApp{} -> cont
+              SetUndefined{} -> cont
+              _ -> Nothing
+        InstructionStart{} -> cont
+        ArchState{} -> cont
+        Comment{} -> cont
+        _ -> Nothing
+  where
+    -- It is possible for later ArchState updates to reference the AssignId of
+    -- the AssignStmt that is dropped, so make sure to prune such updates to
+    -- avoid referencing the now out-of-scope AssignId.
+    dropRefsTo :: AssignId ids tp -> Stmt arch ids -> Stmt arch ids
+    dropRefsTo stmtId stmt =
+      case stmt of
+        ArchState addr updates ->
+          ArchState addr $
+          MapF.filter (\v -> Some stmtId `Set.notMember` refsInValue v) updates
+
+        -- These Stmts don't contain any Values.
+        InstructionStart{} -> stmt
+        Comment{}          -> stmt
+
+        -- stripPLTRead will bail out if it encounters any of these forms of
+        -- Stmt, so we don't need to consider them.
+        AssignStmt{}   -> stmt
+        ExecArchStmt{} -> stmt
+        CondWriteMem{} -> stmt
+        WriteMem{}     -> stmt
+
+removeUnassignedRegs :: forall arch ids
+                     .  RegisterInfo (ArchReg arch)
+                     => RegState (ArchReg arch) (Value arch ids)
+                        -- ^ Initial register values
+                     -> RegState (ArchReg arch) (Value arch ids)
+                        -- ^ Final register values
+                     -> MapF.MapF (ArchReg arch) (Value arch ids)
+removeUnassignedRegs initRegs finalRegs =
+  let keepReg :: forall tp . ArchReg arch tp -> Value arch ids tp -> Bool
+      keepReg r finalVal
+         | Just Refl <- testEquality r ip_reg = False
+         | Just Refl <- testEquality initVal finalVal = False
+         | otherwise = True
+        where initVal = initRegs^.boundValue r
+   in MapF.filterWithKey keepReg (regStateMap finalRegs)
+
+-- | Return true if any value in structure contains the given
+-- identifier.
+containsAssignId :: forall t arch ids itp
+                 .  FoldableF t
+                 => AssignId ids itp
+                    -- ^ Forbidden assignment -- may not appear in terms.
+                 -> t (Value arch ids)
+                 -> Bool
+containsAssignId droppedAssign =
+  let hasId :: forall tp . Value arch ids tp -> Any
+      hasId v = Any (Set.member (Some droppedAssign) (refsInValue v))
+   in getAny . foldMapF hasId
+
+-- | A classifier that attempts to recognize PLT stubs
+pltStubClassifier :: Info.BlockClassifier arch ids
+pltStubClassifier = Info.classifierName "PLT stub" $ do
+  bcc <- CMR.ask
+  let ctx = Info.classifierParseContext bcc
+  let ainfo = Info.pctxArchInfo ctx
+  let mem = Info.pctxMemory ctx
+  Info.withArchConstraints ainfo $ do
+
+    -- The IP should jump to an address in the .got, so try to compute that.
+    AssignedValue (Assignment valId v) <- pure $ Info.classifierFinalRegState bcc ^. boundValue ip_reg
+    ReadMem gotVal _repr <- pure $ v
+    Just gotSegOff <- pure $ valueAsSegmentOff mem gotVal
+    -- The .got contents should point to a relocation to the function
+    -- that we will jump to.
+    Right chunks <- pure $ segoffContentsAfter gotSegOff
+    RelocationRegion r:_ <- pure $ chunks
+    -- Check the relocation satisfies all the constraints we expect on PLT strub
+    SymbolRelocation sym symVer <- pure $ relocationSym r
+    unless (relocationOffset r == 0) $ fail "PLT stub requires 0 offset."
+    when (relocationIsRel r) $ fail "PLT stub requires absolute relocation."
+    when (toInteger (relocationSize r) /= toInteger (addrWidthReprByteCount (Info.archAddrWidth ainfo))) $ do
+      fail $ "PLT stub relocations must match address size."
+    when (relocationIsSigned r) $ do
+      fail $ "PLT stub relocations must be signed."
+    when (relocationEndianness r /= Info.archEndianness ainfo) $ do
+      fail $ "PLT relocation endianness must match architecture."
+    unless (relocationJumpSlot r) $ do
+      fail $ "PLT relocations must be jump slots."
+    -- The PLTStub terminator will implicitly read the GOT address, so we remove
+    -- it from the list of statements.
+    Just strippedStmts <- pure $ stripPLTRead valId (Info.classifierStmts bcc) Seq.empty
+    let strippedRegs = removeUnassignedRegs (Info.classifierInitRegState bcc) (Info.classifierFinalRegState bcc)
+    when (containsAssignId valId strippedRegs) $ do
+      fail $ "PLT IP must be assigned."
+    pure $ Parsed.ParsedContents { Parsed.parsedNonterm = F.toList strippedStmts
+                              , Parsed.parsedTerm  = Parsed.PLTStub strippedRegs gotSegOff (VerSym sym symVer)
+                              , Parsed.writtenCodeAddrs = Info.classifierWrittenAddrs bcc
+                              , Parsed.intraJumpTargets = []
+                              , Parsed.newFunctionAddrs = []
+                              }

--- a/base/src/Data/Macaw/Discovery/ParsedContents.hs
+++ b/base/src/Data/Macaw/Discovery/ParsedContents.hs
@@ -1,0 +1,351 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+-- | Macaw AST elements used after block classification
+--
+-- There are two stages of code discovery:
+--
+-- 1. Initial discovery with simple block terminators (unclassified block terminators like FetchAndExecute)
+--
+-- 2. Classified block terminators (e.g., branch, call, return, etc)
+--
+-- This module defines the AST elements for the latter case.
+module Data.Macaw.Discovery.ParsedContents (
+    ParsedTermStmt(..)
+  , parsedTermSucc
+  , ParsedBlock(..)
+  , ParsedContents(..)
+  , Extension(..)
+  , BlockExploreReason(..)
+  -- * JumpTableLayout
+  , JumpTableLayout(..)
+  , jtlBackingAddr
+  , jtlBackingSize
+  -- * BoundedMemArray
+  , BoundedMemArray(..)
+  , arByteCount
+  , isReadOnlyBoundedMemArray
+  -- * Pretty Printing
+  , ppTermStmt
+  ) where
+
+import qualified Control.Lens as CL
+import           Data.Maybe ( maybeToList )
+import qualified Data.Parameterized.Map as MapF
+import           Data.Text ( Text )
+import qualified Data.Vector as V
+import           Data.Word ( Word64 )
+import qualified Prettyprinter as PP
+import           Prettyprinter ( (<+>) )
+
+import           Data.Macaw.AbsDomain.AbsState ( AbsBlockState )
+import           Data.Macaw.CFG
+import qualified Data.Macaw.AbsDomain.JumpBounds as Jmp
+import qualified Data.Macaw.Memory.Permissions as Perm
+import           Data.Macaw.Types
+
+------------------------------------------------------------------------
+-- BlockExploreReason
+
+-- | This describes why we are exploring a given block within a function.
+data BlockExploreReason w
+   --   -- | Exploring because the given block writes it to memory.
+   --  =- InWrite !(MemSegmentOff w)
+     -- | Exploring because the given block jumps here.
+   = NextIP !(MemSegmentOff w)
+     -- | Identified as an entry point from initial information
+   | FunctionEntryPoint
+     -- | Added because the address split this block after it had been
+     -- disassembled.  Also includes the reason we thought the block
+     -- should be there before we split it.
+   | SplitAt !(MemSegmentOff w) !(BlockExploreReason w)
+     -- The user requested that we analyze this address as a function.
+     -- UserRequest
+
+  deriving (Eq, Show)
+
+-------------------------------------------------------------------------------
+-- BoundedMemArray
+
+-- | This describes a region of memory dereferenced in some array read.
+--
+-- These regions may be be sparse, given an index @i@, the
+-- the address given by @arBase@ + @arIx'*'arStride@.
+data BoundedMemArray arch tp = BoundedMemArray
+  { arBase   :: !(MemSegmentOff (ArchAddrWidth arch))
+    -- ^ The base address for array accesses.
+  , arStride :: !Word64
+    -- ^ Space between elements of the array.
+    --
+    -- This will typically be the number of bytes denoted by `arEltType`,
+    -- but may be larger for sparse arrays.  `matchBoundedMemArray` will fail
+    -- if stride is less than the number of bytes read.
+  , arEltType   :: !(MemRepr tp)
+    -- ^ Resolved type of elements in this array.
+  , arSlices       :: !(V.Vector [MemChunk (ArchAddrWidth arch)])
+    -- ^ The slices of memory in the array.
+    --
+    -- The `i`th element in the vector corresponds to the first `size`
+    -- bytes at address `base + stride * i`.
+    --
+    -- The number of elements is the length of the array.
+    --
+    -- N.B.  With the size could be computed from the previous fields,
+    -- but we check we can create it when creating the array read, so
+    -- we store it to avoid recomputing it.
+  }
+
+deriving instance RegisterInfo (ArchReg arch) => Show (BoundedMemArray arch tp)
+
+-- | Return number of bytes used by this array.
+arByteCount :: BoundedMemArray arch tp -> Word64
+arByteCount a = arStride a * fromIntegral (V.length (arSlices a))
+
+-- | Return true if the address stored is readable and not writable.
+isReadOnlyBoundedMemArray :: BoundedMemArray arch  tp -> Bool
+isReadOnlyBoundedMemArray = Perm.isReadonly . segmentFlags . segoffSegment . arBase
+
+------------------------------------------------------------------------
+-- Extension
+
+-- | Information about a value that is the signed or unsigned extension of another
+-- value.
+--
+-- This is used for jump tables, and only supports widths that are in memory
+data Extension w = Extension { _extIsSigned :: !Bool
+                             , _extWidth :: !(AddrWidthRepr w)
+                               -- ^ Width of argument. is to.
+                             }
+  deriving (Show)
+
+
+------------------------------------------------------------------------
+-- JumpTableLayout
+
+-- | This describes the layout of a jump table.
+-- Beware: on some architectures, after reading from the jump table, the
+-- resulting addresses must be aligned. See the IPAlignment class.
+data JumpTableLayout arch
+  = AbsoluteJumpTable !(BoundedMemArray arch (BVType (ArchAddrWidth arch)))
+  -- ^ @AbsoluteJumpTable r@ describes a jump table where the jump
+  -- target is directly stored in the array read @r@.
+  | forall w . RelativeJumpTable !(ArchSegmentOff arch)
+                                 !(BoundedMemArray arch (BVType w))
+                                 !(Extension w)
+  -- ^ @RelativeJumpTable base read ext@ describes information about a
+  -- jump table where all jump targets are relative to a fixed base
+  -- address.
+  --
+  -- The value is computed as @baseVal + readVal@ where
+  --
+  -- @baseVal = fromMaybe 0 base@, @readVal@ is the value stored at
+  -- the memory read described by @read@ with the sign of @ext@.
+
+deriving instance RegisterInfo (ArchReg arch) => Show (JumpTableLayout arch)
+
+-- | Return base address of table storing contents of jump table.
+jtlBackingAddr :: JumpTableLayout arch ->  ArchSegmentOff arch
+jtlBackingAddr (AbsoluteJumpTable a) = arBase a
+jtlBackingAddr (RelativeJumpTable _ a _) = arBase a
+
+-- | Returns the number of bytes in the layout
+jtlBackingSize :: JumpTableLayout arch -> Word64
+jtlBackingSize (AbsoluteJumpTable a) = arByteCount a
+jtlBackingSize (RelativeJumpTable _ a _) = arByteCount a
+
+------------------------------------------------------------------------
+-- ParsedTermStmt
+
+-- | This term statement is used to describe higher level expressions
+-- of how block ending with a a FetchAndExecute statement should be
+-- interpreted.
+data ParsedTermStmt arch ids
+  -- | A call with the current register values and location to return
+  -- to or 'Nothing' if this is a tail call.
+  --
+  -- Note that the semantics of this instruction assume that the
+  -- program has already stored the return address in the appropriate
+  -- location (which depends on the ABI).  For example on X86_64 this
+  -- is the top of the stack while on ARM this is the link register.
+  = ParsedCall !(RegState (ArchReg arch) (Value arch ids))
+               !(Maybe (ArchSegmentOff arch))
+    -- | @PLTStub regs addr sym symVer@ denotes a terminal statement that
+    -- has been identified as a PLT stub for jumping to the given symbol
+    -- (with optional version information).
+    --
+    -- This is a special case of a tail call.  It has been added
+    -- separately because it occurs frequently in dynamically linked
+    -- code, and we can use this to recognize PLT stubs.
+    --
+    -- The first argument maps registers that were changed to their
+    -- value.  Other registers have the initial value.  This should
+    -- typically be empty on @X86_64@ PLT stubs.
+    --
+    -- The second argument is the address in the .GOT that the target
+    -- function is stored at.  The PLT stub sets the PC to the address
+    -- stored here.
+    --
+    -- The third and fourth arguments are used to resolve where the
+    -- function should jump to.
+  | PLTStub !(MapF.MapF (ArchReg arch) (Value arch ids))
+            !(ArchSegmentOff arch)
+            !VersionedSymbol
+  -- | A jump to an explicit address within a function.
+  | ParsedJump !(RegState (ArchReg arch) (Value arch ids)) !(ArchSegmentOff arch)
+  -- | @ParsedBranch regs cond trueAddr falseAddr@ represents a conditional
+  -- branch that jumps to @trueAddr@ if @cond@ is true and @falseAddr@ otherwise.
+  --
+  -- The value assigned to the IP in @regs@ should reflect this if-then-else
+  -- structure.
+  | ParsedBranch !(RegState (ArchReg arch) (Value arch ids))
+                 !(Value arch ids BoolType)
+                 !(ArchSegmentOff arch)
+                 !(ArchSegmentOff arch)
+  -- | A lookup table that branches to one of a vector of addresses.
+  --
+  -- The registers store the registers, the value contains the index to jump
+  -- to, and the possible addresses as a table.  If the index (when interpreted as
+  -- an unsigned number) is larger than the number of entries in the vector, then the
+  -- result is undefined.
+  | ParsedLookupTable !(JumpTableLayout arch)
+                      !(RegState (ArchReg arch) (Value arch ids))
+                      !(ArchAddrValue arch ids)
+                      !(V.Vector (ArchSegmentOff arch))
+  -- | A return with the given registers.
+  | ParsedReturn !(RegState (ArchReg arch) (Value arch ids))
+  -- | An architecture-specific statement with the registers prior to execution, and
+  -- the given next control flow address.
+  | ParsedArchTermStmt !(ArchTermStmt arch ids)
+                       !(RegState (ArchReg arch) (Value arch ids))
+                       !(Maybe (ArchSegmentOff arch))
+  -- | An error occured in translating the block
+  | ParsedTranslateError !Text
+  -- | The classifier failed to identity the block.
+  -- Includes registers with list of reasons for each classifer to fail
+  | ClassifyFailure !(RegState (ArchReg arch) (Value arch ids)) [String]
+
+ppTermStmt :: ArchConstraints arch
+           => ParsedTermStmt arch ids
+           -> PP.Doc ann
+ppTermStmt tstmt =
+  case tstmt of
+    ParsedCall s Nothing ->
+      PP.vcat
+      [ "tail_call"
+      , PP.indent 2 (PP.pretty s) ]
+    ParsedCall s (Just next) ->
+      PP.vcat
+      [ "call and return to" <+> PP.viaShow next
+      , PP.indent 2 (PP.pretty s) ]
+    PLTStub regs addr sym ->
+      PP.vcat
+      [ "call_via_got" <+> PP.viaShow sym <+> "(at" <+> PP.viaShow addr PP.<> ")"
+      , PP.indent 2 (ppRegMap regs) ]
+    ParsedJump s addr ->
+      PP.vcat
+      [ "jump" <+> PP.viaShow addr
+      , PP.indent 2 (PP.pretty s) ]
+    ParsedBranch r c t f  ->
+      PP.vcat
+      [ "branch" <+> PP.pretty c <+> PP.viaShow t <+> PP.viaShow f
+      , PP.indent 2 (PP.pretty r) ]
+    ParsedLookupTable _layout s idx entries ->
+      PP.vcat
+      [ "ijump" <+> PP.pretty idx
+      , PP.indent 2 (PP.vcat (CL.imap (\i v -> PP.pretty i <+> ":->" <+> PP.viaShow v)
+                             (V.toList entries)))
+      , PP.indent 2 (PP.pretty s) ]
+    ParsedReturn s ->
+      PP.vcat
+      [ "return"
+      , PP.indent 2 (PP.pretty s) ]
+    ParsedArchTermStmt ts s maddr ->
+      PP.vcat
+      [ prettyF ts <> addrDoc
+      , PP.indent 2 (PP.pretty s) ]
+      where
+          addrDoc = case maddr of
+                      Just a -> ", return to" <+> PP.viaShow a
+                      Nothing -> ""
+    ParsedTranslateError msg ->
+      "translation error" <+> PP.pretty msg
+    ClassifyFailure s rsns ->
+      PP.vcat
+      [ "classify failure"
+      , PP.indent 2 (PP.pretty s)
+      , PP.indent 2 (PP.vcat (PP.pretty <$> rsns)) ]
+
+instance ArchConstraints arch => Show (ParsedTermStmt arch ids) where
+  show = show . ppTermStmt
+
+-- | Get all successor blocks for the given list of statements.
+parsedTermSucc :: ParsedTermStmt arch ids -> [ArchSegmentOff arch]
+parsedTermSucc ts = do
+  case ts of
+    ParsedCall _ (Just ret_addr) -> [ret_addr]
+    ParsedCall _ Nothing -> []
+    PLTStub{} -> []
+    ParsedJump _ tgt -> [tgt]
+    ParsedBranch _ _ t f -> [t,f]
+    ParsedLookupTable _layout _ _ v -> V.toList v
+    ParsedReturn{} -> []
+    ParsedArchTermStmt _ _ ret -> maybeToList ret
+    ParsedTranslateError{} -> []
+    ClassifyFailure{} -> []
+
+------------------------------------------------------------------------
+-- ParsedBlock
+
+-- | A contiguous region of instructions in memory.
+data ParsedBlock arch ids
+   = ParsedBlock { pblockAddr :: !(ArchSegmentOff arch)
+                   -- ^ Address of region
+                 , pblockPrecond :: !(Either String (ArchBlockPrecond arch))
+                   -- ^ Architecture-specificic information assumed to
+                   -- be true when jumping to this block, or error why this
+                   -- information could not be obtained.
+                 , blockSize :: !Int
+                   -- ^ The size of the region of memory covered by this.
+                 , blockReason :: !(BlockExploreReason (ArchAddrWidth arch))
+                   -- ^ Reason that we marked this address as
+                   -- the start of a basic block.
+                 , blockAbstractState :: !(AbsBlockState (ArchReg arch))
+                   -- ^ Abstract state prior to the execution of
+                   -- this region.
+                 , blockJumpBounds :: !(Jmp.InitJumpBounds arch)
+                   -- ^ Structure for computing bounds on jump tables.
+                 , pblockStmts :: !([Stmt arch ids])
+                     -- ^ The non-terminal statements in the block
+                 , pblockTermStmt  :: !(ParsedTermStmt arch ids)
+                   -- ^ The terminal statement in the block.
+                 }
+
+deriving instance (ArchConstraints arch, Show (ArchBlockPrecond arch))
+  => Show (ParsedBlock arch ids)
+
+instance ArchConstraints arch
+      => PP.Pretty (ParsedBlock arch ids) where
+  pretty b =
+    PP.vcat
+    [ PP.viaShow (pblockAddr b) PP.<> ":"
+    , PP.indent 2 (PP.vcat $ ("; " <+>) <$> Jmp.ppInitJumpBounds (blockJumpBounds b))
+    , PP.indent 2 (PP.vcat [PP.vcat (ppStmt ppOff <$> pblockStmts b), ppTermStmt (pblockTermStmt b)])
+    ]
+    where ppOff o = PP.viaShow (incAddr (toInteger o) (segoffAddr (pblockAddr b)))
+
+-- | Stores the main block features that may changes from parsing a block.
+data ParsedContents arch ids =
+  ParsedContents { parsedNonterm :: !([Stmt arch ids])
+                   -- ^ The non-terminal statements in the block
+                 , parsedTerm  :: !(ParsedTermStmt arch ids)
+                   -- ^ The terminal statement in the block.
+                 , writtenCodeAddrs :: ![ArchSegmentOff arch]
+                 -- ^ Addresses marked executable that were written to memory.
+                 , intraJumpTargets :: ![Jmp.IntraJumpTarget arch]
+                 , newFunctionAddrs :: ![ArchSegmentOff arch]
+                   -- ^ List of candidate functions found when parsing block.
+                   --
+                   -- Note. In a binary, these could denote the non-executable
+                   -- segments, so they are filtered before traversing.
+                 }

--- a/base/src/Data/Macaw/Discovery/State.hs
+++ b/base/src/Data/Macaw/Discovery/State.hs
@@ -24,7 +24,7 @@ module Data.Macaw.Discovery.State
   , funInfo
   , UnexploredFunctionMap
   , unexploredFunctions
-  , NoReturnFunStatus(..)
+  , Info.NoReturnFunStatus(..)
   , trustedFunctionEntryPoints
   , exploreFnPred
     -- * DiscoveryFunInfo
@@ -32,23 +32,23 @@ module Data.Macaw.Discovery.State
   , discoveredFunName
   , parsedBlocks
     -- ** Parsed block
-  , ParsedBlock(..)
+  , Parsed.ParsedBlock(..)
     -- ** Block terminal statements
-  , ParsedTermStmt(..)
-  , parsedTermSucc
+  , Parsed.ParsedTermStmt(..)
+  , Parsed.parsedTermSucc
     -- ** JumpTableLayout
-  , JumpTableLayout(..)
-  , Extension(..)
-  , jtlBackingAddr
-  , jtlBackingSize
+  , Parsed.JumpTableLayout(..)
+  , Parsed.Extension(..)
+  , Parsed.jtlBackingAddr
+  , Parsed.jtlBackingSize
     -- * BoundedMemArray
-  , BoundedMemArray(..)
-  , arByteCount
-  , isReadOnlyBoundedMemArray
+  , Parsed.BoundedMemArray(..)
+  , Parsed.arByteCount
+  , Parsed.isReadOnlyBoundedMemArray
     -- * Reasons for exploring
   , FunctionExploreReason(..)
   , ppFunReason
-  , BlockExploreReason(..)
+  , Parsed.BlockExploreReason(..)
     -- * DiscoveryState utilities
   , RegConstraint
   )  where
@@ -57,21 +57,14 @@ import           Control.Lens
 import qualified Data.ByteString.Char8 as BSC
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (maybeToList)
 import           Data.Parameterized.Classes
-import qualified Data.Parameterized.Map as MapF
 import           Data.Parameterized.Some
-import           Data.Text (Text)
-import qualified Data.Vector as V
-import           Data.Word
 import           Numeric (showHex)
 import           Prettyprinter as PP
 
-import           Data.Macaw.AbsDomain.AbsState
-import qualified Data.Macaw.AbsDomain.JumpBounds as Jmp
-import           Data.Macaw.Architecture.Info
+import           Data.Macaw.Architecture.Info as Info
 import           Data.Macaw.CFG
-import qualified Data.Macaw.Memory.Permissions as Perm
+import qualified Data.Macaw.Discovery.ParsedContents as Parsed
 import           Data.Macaw.Types
 
 ------------------------------------------------------------------------
@@ -108,26 +101,6 @@ ppFunReason rsn =
     CodePointerInMem a -> " (in initial memory at " ++ showHex (memWordValue (addrOffset (segoffAddr a))) ")"
 
 ------------------------------------------------------------------------
--- BlockExploreReason
-
--- | This describes why we are exploring a given block within a function.
-data BlockExploreReason w
-   --   -- | Exploring because the given block writes it to memory.
-   --  =- InWrite !(MemSegmentOff w)
-     -- | Exploring because the given block jumps here.
-   = NextIP !(MemSegmentOff w)
-     -- | Identified as an entry point from initial information
-   | FunctionEntryPoint
-     -- | Added because the address split this block after it had been
-     -- disassembled.  Also includes the reason we thought the block
-     -- should be there before we split it.
-   | SplitAt !(MemSegmentOff w) !(BlockExploreReason w)
-     -- The user requested that we analyze this address as a function.
-     -- UserRequest
-
-  deriving (Eq, Show)
-
-------------------------------------------------------------------------
 -- GlobalDataInfo
 
 -- | Information about a region of memory.
@@ -143,274 +116,6 @@ instance (Integral w, Show w) => Show (GlobalDataInfo w) where
                             | otherwise = error "jump table with negative offset given"
   show ReferencedValue = "global addr"
 
--------------------------------------------------------------------------------
--- BoundedMemArray
-
--- | This describes a region of memory dereferenced in some array read.
---
--- These regions may be be sparse, given an index @i@, the
--- the address given by @arBase@ + @arIx'*'arStride@.
-data BoundedMemArray arch tp = BoundedMemArray
-  { arBase   :: !(MemSegmentOff (ArchAddrWidth arch))
-    -- ^ The base address for array accesses.
-  , arStride :: !Word64
-    -- ^ Space between elements of the array.
-    --
-    -- This will typically be the number of bytes denoted by `arEltType`,
-    -- but may be larger for sparse arrays.  `matchBoundedMemArray` will fail
-    -- if stride is less than the number of bytes read.
-  , arEltType   :: !(MemRepr tp)
-    -- ^ Resolved type of elements in this array.
-  , arSlices       :: !(V.Vector [MemChunk (ArchAddrWidth arch)])
-    -- ^ The slices of memory in the array.
-    --
-    -- The `i`th element in the vector corresponds to the first `size`
-    -- bytes at address `base + stride * i`.
-    --
-    -- The number of elements is the length of the array.
-    --
-    -- N.B.  With the size could be computed from the previous fields,
-    -- but we check we can create it when creating the array read, so
-    -- we store it to avoid recomputing it.
-  }
-
-deriving instance RegisterInfo (ArchReg arch) => Show (BoundedMemArray arch tp)
-
--- | Return number of bytes used by this array.
-arByteCount :: BoundedMemArray arch tp -> Word64
-arByteCount a = arStride a * fromIntegral (V.length (arSlices a))
-
--- | Return true if the address stored is readable and not writable.
-isReadOnlyBoundedMemArray :: BoundedMemArray arch  tp -> Bool
-isReadOnlyBoundedMemArray = Perm.isReadonly . segmentFlags . segoffSegment . arBase
-
-------------------------------------------------------------------------
--- Extension
-
--- | Information about a value that is the signed or unsigned extension of another
--- value.
---
--- This is used for jump tables, and only supports widths that are in memory
-data Extension w = Extension { _extIsSigned :: !Bool
-                             , _extWidth :: !(AddrWidthRepr w)
-                               -- ^ Width of argument. is to.
-                             }
-  deriving (Show)
-
-
-------------------------------------------------------------------------
--- JumpTableLayout
-
--- | This describes the layout of a jump table.
--- Beware: on some architectures, after reading from the jump table, the
--- resulting addresses must be aligned. See the IPAlignment class.
-data JumpTableLayout arch
-  = AbsoluteJumpTable !(BoundedMemArray arch (BVType (ArchAddrWidth arch)))
-  -- ^ @AbsoluteJumpTable r@ describes a jump table where the jump
-  -- target is directly stored in the array read @r@.
-  | forall w . RelativeJumpTable !(ArchSegmentOff arch)
-                                 !(BoundedMemArray arch (BVType w))
-                                 !(Extension w)
-  -- ^ @RelativeJumpTable base read ext@ describes information about a
-  -- jump table where all jump targets are relative to a fixed base
-  -- address.
-  --
-  -- The value is computed as @baseVal + readVal@ where
-  --
-  -- @baseVal = fromMaybe 0 base@, @readVal@ is the value stored at
-  -- the memory read described by @read@ with the sign of @ext@.
-
-deriving instance RegisterInfo (ArchReg arch) => Show (JumpTableLayout arch)
-
--- | Return base address of table storing contents of jump table.
-jtlBackingAddr :: JumpTableLayout arch ->  ArchSegmentOff arch
-jtlBackingAddr (AbsoluteJumpTable a) = arBase a
-jtlBackingAddr (RelativeJumpTable _ a _) = arBase a
-
--- | Returns the number of bytes in the layout
-jtlBackingSize :: JumpTableLayout arch -> Word64
-jtlBackingSize (AbsoluteJumpTable a) = arByteCount a
-jtlBackingSize (RelativeJumpTable _ a _) = arByteCount a
-
-------------------------------------------------------------------------
--- ParsedTermStmt
-
--- | This term statement is used to describe higher level expressions
--- of how block ending with a a FetchAndExecute statement should be
--- interpreted.
-data ParsedTermStmt arch ids
-  -- | A call with the current register values and location to return
-  -- to or 'Nothing' if this is a tail call.
-  --
-  -- Note that the semantics of this instruction assume that the
-  -- program has already stored the return address in the appropriate
-  -- location (which depends on the ABI).  For example on X86_64 this
-  -- is the top of the stack while on ARM this is the link register.
-  = ParsedCall !(RegState (ArchReg arch) (Value arch ids))
-               !(Maybe (ArchSegmentOff arch))
-    -- | @PLTStub regs addr sym symVer@ denotes a terminal statement that
-    -- has been identified as a PLT stub for jumping to the given symbol
-    -- (with optional version information).
-    --
-    -- This is a special case of a tail call.  It has been added
-    -- separately because it occurs frequently in dynamically linked
-    -- code, and we can use this to recognize PLT stubs.
-    --
-    -- The first argument maps registers that were changed to their
-    -- value.  Other registers have the initial value.  This should
-    -- typically be empty on @X86_64@ PLT stubs.
-    --
-    -- The second argument is the address in the .GOT that the target
-    -- function is stored at.  The PLT stub sets the PC to the address
-    -- stored here.
-    --
-    -- The third and fourth arguments are used to resolve where the
-    -- function should jump to.
-  | PLTStub !(MapF.MapF (ArchReg arch) (Value arch ids))
-            !(ArchSegmentOff arch)
-            !VersionedSymbol
-  -- | A jump to an explicit address within a function.
-  | ParsedJump !(RegState (ArchReg arch) (Value arch ids)) !(ArchSegmentOff arch)
-  -- | @ParsedBranch regs cond trueAddr falseAddr@ represents a conditional
-  -- branch that jumps to @trueAddr@ if @cond@ is true and @falseAddr@ otherwise.
-  --
-  -- The value assigned to the IP in @regs@ should reflect this if-then-else
-  -- structure.
-  | ParsedBranch !(RegState (ArchReg arch) (Value arch ids))
-                 !(Value arch ids BoolType)
-                 !(ArchSegmentOff arch)
-                 !(ArchSegmentOff arch)
-  -- | A lookup table that branches to one of a vector of addresses.
-  --
-  -- The registers store the registers, the value contains the index to jump
-  -- to, and the possible addresses as a table.  If the index (when interpreted as
-  -- an unsigned number) is larger than the number of entries in the vector, then the
-  -- result is undefined.
-  | ParsedLookupTable !(JumpTableLayout arch)
-                      !(RegState (ArchReg arch) (Value arch ids))
-                      !(ArchAddrValue arch ids)
-                      !(V.Vector (ArchSegmentOff arch))
-  -- | A return with the given registers.
-  | ParsedReturn !(RegState (ArchReg arch) (Value arch ids))
-  -- | An architecture-specific statement with the registers prior to execution, and
-  -- the given next control flow address.
-  | ParsedArchTermStmt !(ArchTermStmt arch ids)
-                       !(RegState (ArchReg arch) (Value arch ids))
-                       !(Maybe (ArchSegmentOff arch))
-  -- | An error occured in translating the block
-  | ParsedTranslateError !Text
-  -- | The classifier failed to identity the block.
-  -- Includes registers with list of reasons for each classifer to fail
-  | ClassifyFailure !(RegState (ArchReg arch) (Value arch ids)) [String]
-
-ppTermStmt :: ArchConstraints arch
-           => ParsedTermStmt arch ids
-           -> Doc ann
-ppTermStmt tstmt =
-  case tstmt of
-    ParsedCall s Nothing ->
-      vcat
-      [ "tail_call"
-      , indent 2 (pretty s) ]
-    ParsedCall s (Just next) ->
-      vcat
-      [ "call and return to" <+> viaShow next
-      , indent 2 (pretty s) ]
-    PLTStub regs addr sym ->
-      vcat
-      [ "call_via_got" <+> viaShow sym <+> "(at" <+> viaShow addr PP.<> ")"
-      , indent 2 (ppRegMap regs) ]
-    ParsedJump s addr ->
-      vcat
-      [ "jump" <+> viaShow addr
-      , indent 2 (pretty s) ]
-    ParsedBranch r c t f  ->
-      vcat
-      [ "branch" <+> pretty c <+> viaShow t <+> viaShow f
-      , indent 2 (pretty r) ]
-    ParsedLookupTable _layout s idx entries ->
-      vcat
-      [ "ijump" <+> pretty idx
-      , indent 2 (vcat (imap (\i v -> pretty i <+> ":->" <+> viaShow v)
-                             (V.toList entries)))
-      , indent 2 (pretty s) ]
-    ParsedReturn s ->
-      vcat
-      [ "return"
-      , indent 2 (pretty s) ]
-    ParsedArchTermStmt ts s maddr ->
-      vcat
-      [ prettyF ts <> addrDoc
-      , indent 2 (pretty s) ]
-      where
-          addrDoc = case maddr of
-                      Just a -> ", return to" <+> viaShow a
-                      Nothing -> ""
-    ParsedTranslateError msg ->
-      "translation error" <+> pretty msg
-    ClassifyFailure s rsns ->
-      vcat
-      [ "classify failure"
-      , indent 2 (pretty s)
-      , indent 2 (vcat (pretty <$> rsns)) ]
-
-instance ArchConstraints arch => Show (ParsedTermStmt arch ids) where
-  show = show . ppTermStmt
-
--- | Get all successor blocks for the given list of statements.
-parsedTermSucc :: ParsedTermStmt arch ids -> [ArchSegmentOff arch]
-parsedTermSucc ts = do
-  case ts of
-    ParsedCall _ (Just ret_addr) -> [ret_addr]
-    ParsedCall _ Nothing -> []
-    PLTStub{} -> []
-    ParsedJump _ tgt -> [tgt]
-    ParsedBranch _ _ t f -> [t,f]
-    ParsedLookupTable _layout _ _ v -> V.toList v
-    ParsedReturn{} -> []
-    ParsedArchTermStmt _ _ ret -> maybeToList ret
-    ParsedTranslateError{} -> []
-    ClassifyFailure{} -> []
-
-------------------------------------------------------------------------
--- ParsedBlock
-
--- | A contiguous region of instructions in memory.
-data ParsedBlock arch ids
-   = ParsedBlock { pblockAddr :: !(ArchSegmentOff arch)
-                   -- ^ Address of region
-                 , pblockPrecond :: !(Either String (ArchBlockPrecond arch))
-                   -- ^ Architecture-specificic information assumed to
-                   -- be true when jumping to this block, or error why this
-                   -- information could not be obtained.
-                 , blockSize :: !Int
-                   -- ^ The size of the region of memory covered by this.
-                 , blockReason :: !(BlockExploreReason (ArchAddrWidth arch))
-                   -- ^ Reason that we marked this address as
-                   -- the start of a basic block.
-                 , blockAbstractState :: !(AbsBlockState (ArchReg arch))
-                   -- ^ Abstract state prior to the execution of
-                   -- this region.
-                 , blockJumpBounds :: !(Jmp.InitJumpBounds arch)
-                   -- ^ Structure for computing bounds on jump tables.
-                 , pblockStmts :: !([Stmt arch ids])
-                     -- ^ The non-terminal statements in the block
-                 , pblockTermStmt  :: !(ParsedTermStmt arch ids)
-                   -- ^ The terminal statement in the block.
-                 }
-
-deriving instance (ArchConstraints arch, Show (ArchBlockPrecond arch))
-  => Show (ParsedBlock arch ids)
-
-instance ArchConstraints arch
-      => Pretty (ParsedBlock arch ids) where
-  pretty b =
-    vcat
-    [ viaShow (pblockAddr b) PP.<> ":"
-    , indent 2 (vcat $ ("; " <+>) <$> Jmp.ppInitJumpBounds (blockJumpBounds b))
-    , indent 2 (vcat [vcat (ppStmt ppOff <$> pblockStmts b), ppTermStmt (pblockTermStmt b)])
-    ]
-    where ppOff o = viaShow (incAddr (toInteger o) (segoffAddr (pblockAddr b)))
 
 ------------------------------------------------------------------------
 -- DiscoveryFunInfo
@@ -422,7 +127,7 @@ data DiscoveryFunInfo arch ids
                         -- ^ Address of function entry block.
                       , discoveredFunSymbol :: !(Maybe BSC.ByteString)
                         -- ^ A symbol associated with the definition.
-                      , _parsedBlocks :: !(Map (ArchSegmentOff arch) (ParsedBlock arch ids))
+                      , _parsedBlocks :: !(Map (ArchSegmentOff arch) (Parsed.ParsedBlock arch ids))
                         -- ^ Maps the start addresses of function blocks to their contents
                       , discoveredClassifyFailureResolutions :: [(ArchSegmentOff arch, [ArchSegmentOff arch])]
                         -- ^ A side mapping that records jump targets for
@@ -443,7 +148,7 @@ discoveredFunName finfo =
     Just nm -> nm
     Nothing -> BSC.pack (show (discoveredFunAddr finfo))
 
-parsedBlocks :: Simple Lens (DiscoveryFunInfo arch ids) (Map (ArchSegmentOff arch) (ParsedBlock arch ids))
+parsedBlocks :: Simple Lens (DiscoveryFunInfo arch ids) (Map (ArchSegmentOff arch) (Parsed.ParsedBlock arch ids))
 parsedBlocks = lens _parsedBlocks (\s v -> s { _parsedBlocks = v })
 
 instance ArchConstraints arch => Pretty (DiscoveryFunInfo arch ids) where
@@ -457,15 +162,6 @@ instance ArchConstraints arch => Pretty (DiscoveryFunInfo arch ids) where
                Just sym -> pretty (BSC.unpack sym) <+> "@" <+> addr
                Nothing -> addr
 
-------------------------------------------------------------------------
--- NoReturnFunStatus
-
--- | Flags whether a function is labeled no return or not.
-data NoReturnFunStatus
-   = NoReturnFun
-     -- ^ Function labeled no return
-   | MayReturnFun
-     -- ^ Function may retun
 
 ------------------------------------------------------------------------
 -- DiscoveryState
@@ -494,7 +190,7 @@ data DiscoveryState arch
                       -- they are analyzed.
                       --
                       -- The keys in this map and `_funInfo` should be mutually disjoint.
-                    , _trustedFunctionEntryPoints :: !(Map (ArchSegmentOff arch) NoReturnFunStatus)
+                    , _trustedFunctionEntryPoints :: !(Map (ArchSegmentOff arch) Info.NoReturnFunStatus)
                       -- ^ This is the set of addresses that we treat
                       -- as definitely belonging to function entry
                       -- points.
@@ -544,7 +240,7 @@ emptyDiscoveryState mem addrSymMap info =
   , _globalDataMap       = Map.empty
   , _funInfo             = Map.empty
   , _unexploredFunctions = Map.empty
-  , _trustedFunctionEntryPoints = fmap (\_ -> MayReturnFun) addrSymMap
+  , _trustedFunctionEntryPoints = fmap (\_ -> Info.MayReturnFun) addrSymMap
   , _exploreFnPred       = \_ -> True
   }
 
@@ -564,7 +260,7 @@ funInfo = lens _funInfo (\s v -> s { _funInfo = v })
 
 -- | Retrieves functions that are trusted entry points.
 trustedFunctionEntryPoints
-  :: Simple Lens (DiscoveryState arch) (Map (ArchSegmentOff arch) NoReturnFunStatus)
+  :: Simple Lens (DiscoveryState arch) (Map (ArchSegmentOff arch) Info.NoReturnFunStatus)
 trustedFunctionEntryPoints =
   lens _trustedFunctionEntryPoints (\s v -> s { _trustedFunctionEntryPoints = v })
 

--- a/macaw-aarch32/src/Data/Macaw/ARM.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM.hs
@@ -22,6 +22,7 @@ import qualified Data.Macaw.CFG as MC
 import           Control.Lens ( (^.) )
 import qualified Data.Macaw.Architecture.Info as MI
 import qualified Data.Macaw.CFG.DemandSet as MDS
+import qualified Data.Macaw.Discovery as MD
 import qualified Data.Macaw.Memory as MM
 import qualified SemMC.Architecture.AArch32 as ARM
 
@@ -50,6 +51,7 @@ arm_linux_info =
                         , MI.rewriteArchTermStmt = rewriteTermStmt
                         , MI.archDemandContext = archDemandContext
                         , MI.postArchTermStmtAbsState = postARMTermStmtAbsState preserveRegAcrossSyscall
+                        , MI.archClassifier = MD.defaultClassifier
                         }
 
 archDemandContext :: MDS.DemandContext ARM.AArch32

--- a/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
@@ -21,7 +21,6 @@ module Data.Macaw.ARM.Arch where
 import           Data.Bits ( (.&.) )
 import           Data.Kind ( Type )
 import           Data.Macaw.ARM.ARMReg ()
-import qualified Data.Macaw.Architecture.Info as MAI
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.CFG.Block as MCB
 import           Data.Macaw.CFG.Rewriter ( Rewriter, rewriteValue, appendRewrittenArchStmt
@@ -80,7 +79,7 @@ rewriteStmt s = appendRewrittenArchStmt =<< TF.traverseF rewriteValue s
 
 -- | The ArchBlockPrecond type holds data required for an architecture to compute
 -- new abstract states at the beginning on a block.
-type instance MAI.ArchBlockPrecond ARM.AArch32 = ARMBlockPrecond
+type instance MC.ArchBlockPrecond ARM.AArch32 = ARMBlockPrecond
 
 -- | In order to know how to decode a block, we need to know the value of
 -- PSTATE_T (which is the Thumb/ARM mode) at the beginning of a block. We use

--- a/macaw-aarch32/src/Data/Macaw/ARM/Eval.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Eval.hs
@@ -23,7 +23,6 @@ import           Control.Lens ( (&), (^.), (.~) )
 import qualified Data.Macaw.ARM.ARMReg as AR
 import qualified Data.Macaw.ARM.Arch as AA
 import qualified Data.Macaw.AbsDomain.AbsState as MA
-import qualified Data.Macaw.Architecture.Info as MI
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.AbsDomain.JumpBounds as MJ
 import qualified Data.Macaw.Memory as MM
@@ -78,7 +77,7 @@ initialBlockRegs addr preconds = MSG.initRegState addr &
 -- but it isn't worth the complexity until we encounter it in the wild.
 extractBlockPrecond :: MC.ArchSegmentOff ARM.AArch32
                     -> MA.AbsBlockState (MC.ArchReg ARM.AArch32)
-                    -> Either String (MI.ArchBlockPrecond ARM.AArch32)
+                    -> Either String (MC.ArchBlockPrecond ARM.AArch32)
 extractBlockPrecond _ absState =
   case absState ^. MA.absRegState . MC.boundValue (AR.ARMGlobalBV (ASL.knownGlobalRef @"PSTATE_T")) of
     MA.FinSet (Set.toList -> [bi]) -> Right (MAA.ARMBlockPrecond { MAA.bpPSTATE_T = bi == 1 })

--- a/macaw-ppc/src/Data/Macaw/PPC.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC.hs
@@ -33,6 +33,7 @@ import           Data.Proxy ( Proxy(..) )
 import qualified Data.Macaw.Architecture.Info as MI
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.CFG.DemandSet as MDS
+import qualified Data.Macaw.Discovery as MD
 import qualified Data.Macaw.Memory as MM
 
 import qualified SemMC.Architecture.PPC as PPC
@@ -110,6 +111,7 @@ ppc64_linux_info binData =
                       , MI.initialBlockRegs = PPC.Eval.ppcInitialBlockRegs
                       , MI.archCallParams = PPC.Eval.ppcCallParams (preserveRegAcrossSyscall proxy)
                       , MI.extractBlockPrecond = PPC.Eval.ppcExtractBlockPrecond
+                      , MI.archClassifier = MD.defaultClassifier
                       }
   where
     proxy = Proxy @PPC.V64
@@ -135,6 +137,7 @@ ppc32_linux_info =
                       , MI.initialBlockRegs = PPC.Eval.ppcInitialBlockRegs
                       , MI.archCallParams = PPC.Eval.ppcCallParams (preserveRegAcrossSyscall proxy)
                       , MI.extractBlockPrecond = PPC.Eval.ppcExtractBlockPrecond
+                      , MI.archClassifier = MD.defaultClassifier
                       }
   where
     proxy = Proxy @PPC.V32

--- a/macaw-ppc/src/Data/Macaw/PPC/Arch.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Arch.hs
@@ -36,7 +36,6 @@ import           Data.Parameterized.Classes ( knownRepr )
 import qualified Data.Parameterized.NatRepr as NR
 import qualified Data.Parameterized.TraversableFC as FC
 import qualified Data.Parameterized.TraversableF as TF
-import qualified Data.Macaw.Architecture.Info as MAI
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.CFG.Block as MC
 import           Data.Macaw.CFG.Rewriter ( Rewriter, rewriteValue, evalRewrittenArchFn, appendRewrittenArchStmt )
@@ -60,7 +59,7 @@ instance MSS.SimplifierExtension (SP.AnyPPC v) where
 -- The ArchBlockPrecond type holds data required for an architecture to compute
 -- new abstract states at the beginning on a block.  PowerPC doesn't need any
 -- additional information, so we use ()
-type instance MAI.ArchBlockPrecond (SP.AnyPPC v) = ()
+type instance MC.ArchBlockPrecond (SP.AnyPPC v) = ()
 
 data PPCTermStmt (v :: SP.Variant) ids where
   -- | A representation of the PowerPC @sc@ instruction

--- a/macaw-ppc/src/Data/Macaw/PPC/Eval.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Eval.hs
@@ -25,7 +25,6 @@ import qualified Data.Set as S
 
 import           Data.Macaw.AbsDomain.AbsState as MA
 import qualified Data.Macaw.AbsDomain.JumpBounds as MJ
-import qualified Data.Macaw.Architecture.Info as MI
 import           Data.Macaw.CFG
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Parameterized.Map as MapF
@@ -50,13 +49,13 @@ ppcCallParams preservePred =
 
 ppcInitialBlockRegs :: (PPCArchConstraints v)
                     => ArchSegmentOff (SP.AnyPPC v)
-                    -> MI.ArchBlockPrecond (SP.AnyPPC v)
+                    -> ArchBlockPrecond (SP.AnyPPC v)
                     -> RegState (PPCReg v) (Value (SP.AnyPPC v) ids)
 ppcInitialBlockRegs addr _preconds = MSG.initRegState addr
 
 ppcExtractBlockPrecond :: ArchSegmentOff (SP.AnyPPC v)
                        -> MA.AbsBlockState (PPCReg v)
-                       -> Either String (MI.ArchBlockPrecond (SP.AnyPPC v))
+                       -> Either String (ArchBlockPrecond (SP.AnyPPC v))
 ppcExtractBlockPrecond _ _ = Right ()
 
 preserveRegAcrossSyscall :: (1 <= RegAddrWidth (PPCReg v))

--- a/refinement/tools/Initialization.hs
+++ b/refinement/tools/Initialization.hs
@@ -24,9 +24,9 @@ import qualified Data.ElfEdit as EE
 import qualified Data.Foldable as F
 import qualified Data.Map as M
 import           Data.Proxy ( Proxy(..) )
-import qualified Data.Text.Prettyprint.Doc as PP
 import qualified Lang.Crucible.LLVM.MemModel as LLVM
 import qualified Lumberjack as LJ
+import qualified Prettyprinter as PP
 import qualified System.IO as IO
 import qualified System.Exit as IOE
 

--- a/refinement/tools/Summary.hs
+++ b/refinement/tools/Summary.hs
@@ -14,8 +14,8 @@ import           Data.Monoid
 import           Data.Parameterized.Some ( Some(..) )
 import           Data.Semigroup
 import qualified Data.Set as S
-import           Data.Text.Prettyprint.Doc as PP
 import           Data.Word ( Word64 )
+import           Prettyprinter as PP
 
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as MD

--- a/refinement/tools/run-refinement.hs
+++ b/refinement/tools/run-refinement.hs
@@ -22,9 +22,9 @@ import           Data.Maybe ( isNothing )
 import           Data.Monoid
 import           Data.Parameterized.Some
 import qualified Data.Text.IO as TIO
-import           Data.Text.Prettyprint.Doc as PP
 import qualified Lang.Crucible.LLVM.MemModel as LLVM
 import qualified Options.Applicative as O
+import           Prettyprinter as PP
 
 import           Prelude
 

--- a/x86/src/Data/Macaw/X86.hs
+++ b/x86/src/Data/Macaw/X86.hs
@@ -79,6 +79,7 @@ import qualified Data.Macaw.AbsDomain.StridedInterval as SI
 import           Data.Macaw.Architecture.Info
 import           Data.Macaw.CFG
 import           Data.Macaw.CFG.DemandSet
+import           Data.Macaw.Discovery ( defaultClassifier )
 import qualified Data.Macaw.Memory as MM
 import qualified Data.Macaw.Memory.Permissions as Perm
 import           Data.Macaw.Types
@@ -596,6 +597,7 @@ x86_64_info preservePred =
                    , rewriteArchTermStmt = rewriteX86TermStmt
                    , archDemandContext = x86DemandContext
                    , postArchTermStmtAbsState = postX86TermStmtAbsState preservePred
+                   , archClassifier = defaultClassifier
                    }
 
 -- | Architecture information for X86_64 on FreeBSD.


### PR DESCRIPTION
This change makes the block classifier heuristic part of the `ArchitectureInfo`
structure.  This enables clients and architecture backends to customize the
block classification heuristics.  This is most useful for architectures that
have complex architecture-specific block terminators that require analysis to
generate (e.g., conditional returns).  It will also make macaw-refinement
simpler in the future, as the SMT-based refinement is just an additional block
classifier (but is currently implemented via a hacky side channel).

This change introduces an ancillary change, which should not be very
user-visible.

It splits the Macaw.Discovery and Macaw.Discovery.State modules to break
module import cycles in a way that enables us to expose the classifier.  This
should not be user-visible, as Macaw.Discovery still exports the same
names (with one minor exception that should not appear in user code).

It also moves the definition of the `ArchBlockPrecond` type family; the few
affected places should be updated. User code should probably not be able to see
this.