### PR TITLE
Revise handling of some pointer operations

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -1269,6 +1269,8 @@ execMacawStmtExtension (SB.MacawArchEvalFn archStmtFn) mvar globs (MO.LookupFunc
     PtrSub w x y                -> doPtrSub st mvar w x y
     PtrAnd w x y                -> doPtrAnd st mvar w x y
     PtrXor w x y                -> doPtrXor st mvar w x y
+    PtrTrunc w x                -> doPtrTrunc st mvar x w
+    PtrUExt w x                 -> doPtrUExt st mvar x w
 
 
 -- | Return macaw extension evaluation functions.


### PR DESCRIPTION
Have all additions (at any bit width) go through the special PtrAdd
handler (rather than BVAdd). Also add special handlers for truncation and
extension.

These changes support architectures that do pointer operations at non-pointer
widths (e.g., to detect overflow).  These new operations apply the named
operations over just the offset of pointers, preserving the block id.

Prior to this change, additions at non-pointer bit widths (and also ext/truncs) would throw away the block ID, breaking pointers.