### PR TITLE
`macaw-symbolic`: Consolidate `toCrucibleEndian` definitions, add `fromCrucibleEndian`

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -174,7 +174,7 @@ data MemPtrTable sym w =
               -- ^ Pointer width representative
               }
 
--- | Convert a Macaw Endianness to a Crucible LLVM EndianForm
+-- | Convert a Macaw 'MC.Endianness' to a Crucible LLVM 'CLD.EndianForm'.
 toCrucibleEndian :: MC.Endianness -> CLD.EndianForm
 toCrucibleEndian MC.BigEndian    = CLD.BigEndian
 toCrucibleEndian MC.LittleEndian = CLD.LittleEndian

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -104,6 +104,7 @@ module Data.Macaw.Symbolic.Memory (
   -- * Memory Management
   MemPtrTable,
   toCrucibleEndian,
+  fromCrucibleEndian,
   newGlobalMemory,
   GlobalMemoryHooks(..),
   defaultGlobalMemoryHooks,
@@ -178,6 +179,11 @@ data MemPtrTable sym w =
 toCrucibleEndian :: MC.Endianness -> CLD.EndianForm
 toCrucibleEndian MC.BigEndian    = CLD.BigEndian
 toCrucibleEndian MC.LittleEndian = CLD.LittleEndian
+
+-- | Convert a Crucible LLVM 'CLD.EndianForm' to a Macaw 'MC.Endianness'.
+fromCrucibleEndian :: CLD.EndianForm -> MC.Endianness
+fromCrucibleEndian CLD.BigEndian    = MC.BigEndian
+fromCrucibleEndian CLD.LittleEndian = MC.LittleEndian
 
 -- | Hooks to configure the initialization of global memory
 data GlobalMemoryHooks w =

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -233,7 +233,7 @@ simulateAndVerify goalSolver logger sym execFeatures archInfo archVals mem (Resu
     halloc <- CFH.newHandleAllocator
     CCC.SomeCFG g <- MS.mkFunCFG (MS.archFunctions archVals) halloc funName posFn dfi
 
-    let endianness = toCrucibleEndian (MAI.archEndianness archInfo)
+    let endianness = MSM.toCrucibleEndian (MAI.archEndianness archInfo)
     let ?recordLLVMAnnotation = \_ _ _ -> return ()
     (initMem, memPtrTbl) <- MSM.newGlobalMemory (Proxy @arch) sym endianness MSM.ConcreteMutable mem
     let globalMap = MSM.mapRegionPointers memPtrTbl
@@ -402,10 +402,3 @@ lookupSyscall = MS.unsupportedSyscalls "macaw-symbolic-tests"
 -- parameter.
 validityCheck :: MS.MkGlobalPointerValidityAssertion sym w
 validityCheck _ _ _ _ = return Nothing
-
--- | Convert from macaw endianness to the LLVM memory model endianness
-toCrucibleEndian :: MEL.Endianness -> CLD.EndianForm
-toCrucibleEndian e =
-  case e of
-    MM.LittleEndian -> CLD.LittleEndian
-    MM.BigEndian -> CLD.BigEndian


### PR DESCRIPTION
There were two identical definitions of `toCrucibleEndian`, one in `D.M.S.Memory` and another in `D.M.S.Testing`. This commit removes the latter in favor of the former, which is actually exported.

I also added a `fromCrucibleEndian` function, which is useful in similar contexts. `fromCrucibleEndian` is like `toCrucibleEndian`, but in the opposite direction.