### PR TITLE
Only fix personality to (MS.MacawSimulatorState sym) where required. (take two)

### DIFF
--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic.hs
@@ -75,7 +75,7 @@ aarch32RegName r = WS.safeSymbol ("r!" ++ show (MC.prettyF r))
 aarch32MacawEvalFn :: (CB.IsSymInterface sym)
                    => AF.SymFuns sym
                    -> MS.MacawArchStmtExtensionOverride SA.AArch32
-                   -> MS.MacawArchEvalFn sym mem SA.AArch32
+                   -> MS.MacawArchEvalFn p sym mem SA.AArch32
 aarch32MacawEvalFn fs (MS.MacawArchStmtExtensionOverride override) =
   MSB.MacawArchEvalFn $ \_ _ xt s -> do
     mRes <- override xt s

--- a/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Functions.hs
+++ b/macaw-aarch32-symbolic/src/Data/Macaw/AArch32/Symbolic/Functions.hs
@@ -57,7 +57,7 @@ newSymFuns _sym = do
   r <- IOR.newIORef Map.empty
   return SymFuns { symFuns = r }
 
-type S sym rtp bs r ctx = CS.CrucibleState (MS.MacawSimulatorState sym) sym (MS.MacawExt SA.AArch32) rtp bs r ctx
+type S p sym rtp bs r ctx = CS.CrucibleState p sym (MS.MacawExt SA.AArch32) rtp bs r ctx
 
 -- | Semantics for statement syntax extensions
 --
@@ -67,8 +67,8 @@ type S sym rtp bs r ctx = CS.CrucibleState (MS.MacawSimulatorState sym) sym (MS.
 stmtSemantics :: (CB.IsSymInterface sym)
               => SymFuns sym
               -> MAA.ARMStmt (AA.AtomWrapper (CS.RegEntry sym))
-              -> S sym rtp bs r ctx
-              -> IO (CS.RegValue sym CT.UnitType, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (CS.RegValue sym CT.UnitType, S p sym rtp bs r ctx)
 stmtSemantics _sfns stmt _st0 =
   case stmt of
     MAA.UninterpretedA32Opcode opc _ops ->
@@ -79,8 +79,8 @@ stmtSemantics _sfns stmt _st0 =
 funcSemantics :: (CB.IsSymInterface sym, MS.ToCrucibleType mt ~ t)
               => SymFuns sym
               -> MAA.ARMPrimFn (AA.AtomWrapper (CS.RegEntry sym)) mt
-              -> S sym rtp bs r ctx
-              -> IO (CS.RegValue sym t, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (CS.RegValue sym t, S p sym rtp bs r ctx)
 funcSemantics sfns fn st0 =
    case fn of
     MAA.SDiv _rep lhs rhs -> withBackend st0 $ \sym bak -> do
@@ -141,9 +141,9 @@ funcSemantics sfns fn st0 =
       AP.panic AP.AArch32 "funcSemantics" ["The ARM syscall primitive should be eliminated and replaced by a handle lookup"]
 
 withBackend ::
-  S sym rtp bs r ctx ->
+  S p sym rtp bs r ctx ->
   (forall bak. CB.IsSymBackend sym bak => sym -> bak -> IO a) ->
-  IO (a, S sym rtp bs r ctx)
+  IO (a, S p sym rtp bs r ctx)
 withBackend s action = do
   CSET.withBackend (s^.CSET.stateContext) $ \bak ->
     do val <- action (CB.backendGetSym bak) bak

--- a/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic.hs
+++ b/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic.hs
@@ -120,7 +120,7 @@ ppcMacawEvalFn :: ( C.IsSymInterface sym
                   )
                => F.SymFuns sym
                -> MS.MacawArchStmtExtensionOverride (SP.AnyPPC v)
-               -> MS.MacawArchEvalFn sym mem (SP.AnyPPC v)
+               -> MS.MacawArchEvalFn p sym mem (SP.AnyPPC v)
 ppcMacawEvalFn fs (MS.MacawArchStmtExtensionOverride override) =
   MSB.MacawArchEvalFn $ \_ _ xt s -> do
     mRes <- override xt s

--- a/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic/Functions.hs
+++ b/macaw-ppc-symbolic/src/Data/Macaw/PPC/Symbolic/Functions.hs
@@ -65,15 +65,15 @@ instance X.Exception SemanticsError
 termSemantics :: (C.IsSymInterface sym, 1 <= SP.AddrWidth v)
               => SymFuns sym
               -> MP.PPCTermStmt v ids
-              -> S v sym rtp bs r ctx
-              -> IO (C.RegValue sym C.UnitType, S v sym rtp bs r ctx)
+              -> S p v sym rtp bs r ctx
+              -> IO (C.RegValue sym C.UnitType, S p v sym rtp bs r ctx)
 termSemantics = error "PowerPC-specific terminator statement semantics not yet implemented"
 
 stmtSemantics :: (C.IsSymInterface sym, 1 <= SP.AddrWidth v)
               => SymFuns sym
               -> MP.PPCStmt v (A.AtomWrapper (C.RegEntry sym))
-              -> S v sym rtp bs r ctx
-              -> IO (C.RegValue sym C.UnitType, S v sym rtp bs r ctx)
+              -> S p v sym rtp bs r ctx
+              -> IO (C.RegValue sym C.UnitType, S p v sym rtp bs r ctx)
 stmtSemantics _sf stmt s =
   C.withBackend (s ^. C.stateContext) $ \bak ->
   case stmt of
@@ -115,8 +115,8 @@ stmtSemantics _sf stmt s =
 funcSemantics :: (C.IsSymInterface sym, MS.ToCrucibleType mt ~ t, 1 <= SP.AddrWidth v)
               => SymFuns sym
               -> MP.PPCPrimFn v (A.AtomWrapper (C.RegEntry sym)) mt
-              -> S v sym rtp bs r ctx
-              -> IO (C.RegValue sym t, S v sym rtp bs r ctx)
+              -> S p v sym rtp bs r ctx
+              -> IO (C.RegValue sym t, S p v sym rtp bs r ctx)
 funcSemantics sf pf s =
   C.withBackend (s ^. C.stateContext) $ \bak ->
   let sym = C.backendGetSym bak in
@@ -354,9 +354,9 @@ toValFloat _ (A.AtomWrapper x) = C.regValue x
 
 withSym
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> (sym -> IO a)
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSym s action = do
   let sym = s ^. C.stateSymInterface
   val <- action sym
@@ -364,10 +364,10 @@ withSym s action = do
 
 withSymBVUnOp
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> A.AtomWrapper (C.RegEntry sym) (MT.BVType w)
   -> (sym -> C.RegValue sym (C.BVType w) -> IO a)
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSymBVUnOp s x action =
   C.withBackend (s^.C.stateContext) $ \bak ->
     do val <- action (C.backendGetSym bak) =<< toValBV bak x
@@ -375,18 +375,18 @@ withSymBVUnOp s x action =
 
 withSymFPUnOp
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> A.AtomWrapper (C.RegEntry sym) (MT.FloatType fi)
   -> (  sym
      -> C.RegValue sym (MS.ToCrucibleType (MT.FloatType fi))
      -> IO a
      )
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSymFPUnOp s x action = withSym s $ \sym -> action sym $ toValFloat sym x
 
 withSymFPBinOp
   :: (C.IsSymInterface sym)
-  => S v sym rtp bs r ctx
+  => S p v sym rtp bs r ctx
   -> A.AtomWrapper (C.RegEntry sym) (MT.FloatType fi)
   -> A.AtomWrapper (C.RegEntry sym) (MT.FloatType fi)
   -> (  sym
@@ -394,7 +394,7 @@ withSymFPBinOp
      -> C.RegValue sym (MS.ToCrucibleType (MT.FloatType fi))
      -> IO a
      )
-  -> IO (a, S v sym rtp bs r ctx)
+  -> IO (a, S p v sym rtp bs r ctx)
 withSymFPBinOp s x y action = withSym s $ \sym -> do
   let x' = toValFloat sym x
   let y' = toValFloat sym y
@@ -410,4 +410,4 @@ withRounding bak r action = do
   r' <- toValBV bak r
   U.withRounding (C.backendGetSym bak) r' action
 
-type S v sym rtp bs r ctx = C.CrucibleState (MS.MacawSimulatorState sym) sym (MS.MacawExt (SP.AnyPPC v)) rtp bs r ctx
+type S p v sym rtp bs r ctx = C.CrucibleState p sym (MS.MacawExt (SP.AnyPPC v)) rtp bs r ctx

--- a/symbolic/ChangeLog.md
+++ b/symbolic/ChangeLog.md
@@ -6,6 +6,15 @@
 
 ### API Changes
 
+- The types of various functions, such as `macawExtensions`, are now parametric
+  over the `personality` type variable instead of restricting it to
+  `MacawSimulatorState sym`. A consequence of this change is that the
+  `MacawArchEvalFn`, `LookupFunctionHandle`, and `LookupSyscallHandle` data
+  types now have an additional `personality` type variable. If you don't care
+  about this type variable, it is usually fine to leave it polymorphic.
+  Alternatively, one can instantiate it to `MacawSimulatorState sym` to
+  restore the old behavior.
+
 - `Data.Macaw.Symbolic.MemOps.GlobalMap` has changed from a `type`
   synonym to a `newtype`, and its type has changed somewhat.
 

--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -1155,7 +1155,7 @@ type MkGlobalPointerValidityAssertion sym w = sym
 unsupportedFunctionCalls
   :: String
   -- ^ The name of the component providing the handler
-  -> MO.LookupFunctionHandle sym arch
+  -> MO.LookupFunctionHandle p sym arch
 unsupportedFunctionCalls compName =
   MO.LookupFunctionHandle $ \_ _ _ -> error ("Symbolically executing function calls is not supported in " ++ compName)
 
@@ -1168,7 +1168,7 @@ unsupportedFunctionCalls compName =
 unsupportedSyscalls
   :: String
   -- ^ The name of the component providing the handler
-  -> MO.LookupSyscallHandle sym arch
+  -> MO.LookupSyscallHandle p sym arch
 unsupportedSyscalls compName =
   MO.LookupSyscallHandle $ \_ _ _ _ -> error ("Symbolically executing system calls is not supported in " ++ compName)
 
@@ -1182,10 +1182,10 @@ execMacawStmtExtension
   -- ^ The distinguished global variable holding the current state of the memory model
   -> MO.GlobalMap sym MM.Mem (M.ArchAddrWidth arch)
   -- ^ The translation from machine words to LLVM memory model pointers
-  -> MO.LookupFunctionHandle sym arch
+  -> MO.LookupFunctionHandle p sym arch
   -- ^ A function to turn machine addresses into Crucible function
   -- handles (which can also perform lazy CFG creation)
-  -> MO.LookupSyscallHandle sym arch
+  -> MO.LookupSyscallHandle p sym arch
   -- ^ A function to examine the machine state to determine which system call
   -- should be invoked; returns the function handle to invoke
   -> MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
@@ -1281,10 +1281,10 @@ macawExtensions
   -- model
   -> GlobalMap sym MM.Mem (M.ArchAddrWidth arch)
   -- ^ A function that maps bitvectors to valid memory model pointers
-  -> LookupFunctionHandle sym arch
+  -> LookupFunctionHandle personality sym arch
   -- ^ A function to translate virtual addresses into function handles
   -- dynamically during symbolic execution
-  -> MO.LookupSyscallHandle sym arch
+  -> MO.LookupSyscallHandle personality sym arch
   -- ^ A function to examine the machine state to determine which system call
   -- should be invoked; returns the function handle to invoke
   -> MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
@@ -1307,8 +1307,8 @@ runCodeBlock
   -> SB.MacawArchEvalFn (MacawSimulatorState sym) sym MM.Mem arch
   -> C.HandleAllocator
   -> (MM.MemImpl sym, GlobalMap sym MM.Mem (M.ArchAddrWidth arch))
-  -> LookupFunctionHandle sym arch
-  -> MO.LookupSyscallHandle sym arch
+  -> LookupFunctionHandle (MacawSimulatorState sym) sym arch
+  -> MO.LookupSyscallHandle (MacawSimulatorState sym) sym arch
   -> MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
   -> C.CFG (MacawExt arch) blocks (EmptyCtx ::> ArchRegStruct arch) (ArchRegStruct arch)
   -> Ctx.Assignment (C.RegValue' sym) (MacawCrucibleRegTypes arch)

--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -267,11 +267,11 @@ data GenArchVals mem arch = GenArchVals
   -- ^ This is the set of functions used by the translator, and is passed as the
   -- first argument to the translation functions (e.g., 'mkBlocksCFG').
   , withArchEval
-      :: forall a m sym
+      :: forall a m p sym
        . ( IsSymInterface sym, IsMemoryModel mem, MemModelConstraint mem sym, MonadIO m
          , ?memOpts :: MM.MemOptions )
       => sym
-      -> (SB.MacawArchEvalFn sym (MemModelType mem arch) arch -> m a)
+      -> (SB.MacawArchEvalFn p sym (MemModelType mem arch) arch -> m a)
       -> m a
   -- ^ This function provides a context with a callback that gives access to the
   -- set of architecture-specific function evaluators ('MacawArchEvalFn'), which
@@ -1174,9 +1174,9 @@ unsupportedSyscalls compName =
 
 -- | This evaluates a Macaw statement extension in the simulator.
 execMacawStmtExtension
-  :: forall sym arch
+  :: forall p sym arch
   . (IsSymInterface sym, MM.HasLLVMAnn sym, ?memOpts :: MM.MemOptions)
-  => SB.MacawArchEvalFn sym MM.Mem arch
+  => SB.MacawArchEvalFn p sym MM.Mem arch
   -- ^ Simulation-time interpretations of architecture-specific functions
   -> C.GlobalVar MM.Mem
   -- ^ The distinguished global variable holding the current state of the memory model
@@ -1190,7 +1190,7 @@ execMacawStmtExtension
   -- should be invoked; returns the function handle to invoke
   -> MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
   -- ^ A function to make memory validity predicates (see 'MkGlobalPointerValidityAssertion' for details)
-  -> SB.MacawEvalStmtFunc (MacawStmtExtension arch) (MacawSimulatorState sym) sym (MacawExt arch)
+  -> SB.MacawEvalStmtFunc (MacawStmtExtension arch) p sym (MacawExt arch)
 execMacawStmtExtension (SB.MacawArchEvalFn archStmtFn) mvar globs (MO.LookupFunctionHandle lookupH) (MO.LookupSyscallHandle lookupSyscall) toMemPred s0 st =
   C.withBackend (st^.C.stateContext) $ \bak ->
   let sym = backendGetSym bak in
@@ -1274,7 +1274,7 @@ execMacawStmtExtension (SB.MacawArchEvalFn archStmtFn) mvar globs (MO.LookupFunc
 -- | Return macaw extension evaluation functions.
 macawExtensions
   :: (IsSymInterface sym, MM.HasLLVMAnn sym, ?memOpts :: MM.MemOptions)
-  => SB.MacawArchEvalFn sym MM.Mem arch
+  => SB.MacawArchEvalFn personality sym MM.Mem arch
   -- ^ A set of interpretations for architecture-specific functions
   -> C.GlobalVar MM.Mem
   -- ^ The Crucible global variable containing the current state of the memory
@@ -1289,7 +1289,7 @@ macawExtensions
   -- should be invoked; returns the function handle to invoke
   -> MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
   -- ^ A function to make memory validity predicates (see 'MkGlobalPointerValidityAssertion' for details)
-  -> C.ExtensionImpl (MacawSimulatorState sym) sym (MacawExt arch)
+  -> C.ExtensionImpl personality sym (MacawExt arch)
 macawExtensions f mvar globs lookupH lookupSyscall toMemPred =
   C.ExtensionImpl { C.extensionEval = \sym iTypes logFn cst g -> evalMacawExprExtension sym iTypes logFn cst g
                   , C.extensionExec = execMacawStmtExtension f mvar globs lookupH lookupSyscall toMemPred
@@ -1304,7 +1304,7 @@ runCodeBlock
   => bak
   -> MacawSymbolicArchFunctions arch
   -- ^ Translation functions
-  -> SB.MacawArchEvalFn sym MM.Mem arch
+  -> SB.MacawArchEvalFn (MacawSimulatorState sym) sym MM.Mem arch
   -> C.HandleAllocator
   -> (MM.MemImpl sym, GlobalMap sym MM.Mem (M.ArchAddrWidth arch))
   -> LookupFunctionHandle sym arch

--- a/symbolic/src/Data/Macaw/Symbolic/Backend.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Backend.hs
@@ -77,11 +77,11 @@ type MacawEvalStmtFunc f p sym ext =
 -- architecture-specific backends - client code should not need to construct
 -- values of this type, and instead should obtain values of this type from the
 -- 'withArchEval' function.
-newtype MacawArchEvalFn sym mem arch =
+newtype MacawArchEvalFn p sym mem arch =
   MacawArchEvalFn (C.GlobalVar mem
                   -> MO.GlobalMap sym mem (M.ArchAddrWidth arch)
                   -> MacawEvalStmtFunc (CG.MacawArchStmtExtension arch)
-                                       (MO.MacawSimulatorState sym)
+                                       p
                                        sym
                                        (CG.MacawExt arch))
 

--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -153,7 +153,7 @@ ptrBase = fst . llvmPointerView
 -- that allocation.
 newtype GlobalMap sym mem w =
   GlobalMap
-  { applyGlobalMap :: 
+  { applyGlobalMap ::
       forall bak. IsSymBackend sym bak =>
        bak                        {- The symbolic backend -} ->
        GetIntrinsic sym mem       {- The global handle to the memory model -} ->
@@ -371,11 +371,11 @@ type Regs sym arch = Ctx.Assignment (C.RegValue' sym)
 -- constructing the CFG of the callee on the fly) and register them with the
 -- simulator.
 newtype LookupFunctionHandle sym arch = LookupFunctionHandle
-     (forall rtp blocks r ctx
-   . CrucibleState (MacawSimulatorState sym) sym (MacawExt arch) rtp blocks r ctx
+     (forall rtp blocks r ctx p
+   . CrucibleState p sym (MacawExt arch) rtp blocks r ctx
   -> MemImpl sym
   -> Ctx.Assignment (C.RegValue' sym) (MacawCrucibleRegTypes arch)
-  -> IO (C.FnHandle (Ctx.EmptyCtx Ctx.::> ArchRegStruct arch) (ArchRegStruct arch), CrucibleState (MacawSimulatorState sym) sym (MacawExt arch) rtp blocks r ctx))
+  -> IO (C.FnHandle (Ctx.EmptyCtx Ctx.::> ArchRegStruct arch) (ArchRegStruct arch), CrucibleState p sym (MacawExt arch) rtp blocks r ctx))
 
 -- | A function to inspect the machine state and translate it into a
 -- 'C.FnHandle' corresponding to the system call model that the simulator should
@@ -396,12 +396,12 @@ newtype LookupFunctionHandle sym arch = LookupFunctionHandle
 -- backend (e.g., macaw-x86) to ensure that the returned values are placed in
 -- the appropriate machine registers.
 newtype LookupSyscallHandle sym arch =
-  LookupSyscallHandle (  forall rtp blocks r ctx atps rtps
+  LookupSyscallHandle (  forall rtp blocks r ctx atps rtps p
                       .  Ctx.Assignment TypeRepr atps
                       -> Ctx.Assignment TypeRepr rtps
-                      -> CrucibleState (MacawSimulatorState sym) sym (MacawExt arch) rtp blocks r ctx
+                      -> CrucibleState p sym (MacawExt arch) rtp blocks r ctx
                       -> C.RegEntry sym (StructType atps)
-                      -> IO (C.FnHandle atps (StructType rtps), CrucibleState (MacawSimulatorState sym) sym (MacawExt arch) rtp blocks r ctx)
+                      -> IO (C.FnHandle atps (StructType rtps), CrucibleState p sym (MacawExt arch) rtp blocks r ctx)
                       )
 
 --------------------------------------------------------------------------------

--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -370,8 +370,8 @@ type Regs sym arch = Ctx.Assignment (C.RegValue' sym)
 -- 'CrucibleState' to allow the callback to lazily instantiate callees (e.g., by
 -- constructing the CFG of the callee on the fly) and register them with the
 -- simulator.
-newtype LookupFunctionHandle sym arch = LookupFunctionHandle
-     (forall rtp blocks r ctx p
+newtype LookupFunctionHandle p sym arch = LookupFunctionHandle
+     (forall rtp blocks r ctx
    . CrucibleState p sym (MacawExt arch) rtp blocks r ctx
   -> MemImpl sym
   -> Ctx.Assignment (C.RegValue' sym) (MacawCrucibleRegTypes arch)
@@ -395,8 +395,8 @@ newtype LookupFunctionHandle sym arch = LookupFunctionHandle
 -- returned). Note that it is the responsibility of the architecture-specific
 -- backend (e.g., macaw-x86) to ensure that the returned values are placed in
 -- the appropriate machine registers.
-newtype LookupSyscallHandle sym arch =
-  LookupSyscallHandle (  forall rtp blocks r ctx atps rtps p
+newtype LookupSyscallHandle p sym arch =
+  LookupSyscallHandle (  forall rtp blocks r ctx atps rtps
                       .  Ctx.Assignment TypeRepr atps
                       -> Ctx.Assignment TypeRepr rtps
                       -> CrucibleState p sym (MacawExt arch) rtp blocks r ctx

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -440,13 +440,13 @@ data ResultExtractor sym arch where
 -- | The test harness does not currently support calling functions from test cases.
 --
 -- It could be modified to do so.
-lookupFunction :: MS.LookupFunctionHandle sym arch
+lookupFunction :: MS.LookupFunctionHandle p sym arch
 lookupFunction = MS.unsupportedFunctionCalls "macaw-symbolic-tests"
 
 -- | The test harness does not currently support making system calls from test cases.
 --
 -- It could be modified to do so.
-lookupSyscall :: MS.LookupSyscallHandle sym arch
+lookupSyscall :: MS.LookupSyscallHandle p sym arch
 lookupSyscall = MS.unsupportedSyscalls "macaw-symbolic-tests"
 
 -- | The test suite does not currently generate global pointer well-formedness

--- a/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Crucible.hs
@@ -86,15 +86,15 @@ import qualified Data.Macaw.X86.ArchTypes as M
 import           Prelude
 
 
-type S sym rtp bs r ctx =
-  CrucibleState (MacawSimulatorState sym) sym (MacawExt M.X86_64) rtp bs r ctx
+type S p sym rtp bs r ctx =
+  CrucibleState p sym (MacawExt M.X86_64) rtp bs r ctx
 
 funcSemantics
   :: (IsSymInterface sym, ToCrucibleType mt ~ t)
   => SymFuns sym
   -> M.X86PrimFn (AtomWrapper (RegEntry sym)) mt
-  -> S sym rtp bs r ctx
-  -> IO (RegValue sym t, S sym rtp bs r ctx)
+  -> S p sym rtp bs r ctx
+  -> IO (RegValue sym t, S p sym rtp bs r ctx)
 funcSemantics fs x s =
   withBackend (s^.stateContext) $ \bak ->
     do let sym = Sym
@@ -108,12 +108,12 @@ funcSemantics fs x s =
 
 withConcreteCountAndDir
   :: (IsSymInterface sym, 1 <= w)
-  => S sym rtp bs r ctx
+  => S p sym rtp bs r ctx
   -> M.RepValSize w
   -> (AtomWrapper (RegEntry sym) (M.BVType 64))
   -> (AtomWrapper (RegEntry sym) M.BoolType)
-  -> (S sym rtp bs r ctx -> (SymBV sym 64) -> IO (S sym rtp bs r ctx))
-  -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
+  -> (S p sym rtp bs r ctx -> (SymBV sym 64) -> IO (S p sym rtp bs r ctx))
+  -> IO (RegValue sym UnitType, S p sym rtp bs r ctx)
 withConcreteCountAndDir state val_size wrapped_count _wrapped_dir func =
   withBackend (state^.stateContext) $ \bak -> do
   let sym = backendGetSym bak
@@ -135,8 +135,8 @@ stmtSemantics
   -> C.GlobalVar Mem
   -> GlobalMap sym Mem (M.ArchAddrWidth M.X86_64)
   -> M.X86Stmt (AtomWrapper (RegEntry sym))
-  -> S sym rtp bs r ctx
-  -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
+  -> S p sym rtp bs r ctx
+  -> IO (RegValue sym UnitType, S p sym rtp bs r ctx)
 stmtSemantics _sym_funs global_var_mem globals stmt state =
   withBackend (state^.stateContext) $ \bak ->
   let sym = backendGetSym bak in
@@ -180,8 +180,8 @@ stmtSemantics _sym_funs global_var_mem globals stmt state =
 termSemantics :: (IsSymInterface sym)
               => SymFuns sym
               -> M.X86TermStmt (AtomWrapper (RegEntry sym))
-              -> S sym rtp bs r ctx
-              -> IO (RegValue sym UnitType, S sym rtp bs r ctx)
+              -> S p sym rtp bs r ctx
+              -> IO (RegValue sym UnitType, S p sym rtp bs r ctx)
 termSemantics _fs x _s = error ("Symbolic execution semantics for x86 terminators are not implemented yet: " <>
                                 show (MC.ppArchTermStmt (error "Can't print RegEntry") x))
 

--- a/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
+++ b/x86_symbolic/src/Data/Macaw/X86/Symbolic.hs
@@ -348,7 +348,7 @@ x86_64MacawEvalFn
   :: (C.IsSymInterface sym, MM.HasLLVMAnn sym, ?memOpts :: MM.MemOptions)
   => SymFuns sym
   -> MacawArchStmtExtensionOverride M.X86_64
-  -> MacawArchEvalFn sym MM.Mem M.X86_64
+  -> MacawArchEvalFn p sym MM.Mem M.X86_64
 x86_64MacawEvalFn fs (MacawArchStmtExtensionOverride override) =
   MacawArchEvalFn $ \global_var_mem globals ext_stmt crux_state -> do
     mRes <- override ext_stmt crux_state


### PR DESCRIPTION
This is the same patch as #203, but rebased and with an additional commit to parameterize `Lookup{Function,Syscall}Handle` by the `personality` type variable, which proves handy in my particular use case. I've also added another commit to note these changes in the `macaw-symbolic` changelog.