### PR TITLE
Update softfloat-hs repo to eliminate manual build step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,11 +54,9 @@ jobs:
           language-pack-en-base language-pack-en
         sudo locale-gen en_US.UTF-8
         sudo update-locale LANG=$LANG LANGUAGE=$LANGUAGE
-        # Install softfloat
+        # Softfloat repo needs to be recursively cloned
         cd deps/softfloat-hs
         git submodule update --init --recursive
-        make
-        sudo make install
         cd ../..
 
     - name: Copy cabal project files

--- a/README.md
+++ b/README.md
@@ -62,20 +62,17 @@ supported via Git submodules:
 
     $ git submodule update --init
 
-### Installing Softfloat for RISC-V Backend
+### Preparing Softfloat for RISC-V Backend
 
 The RISC-V backend depends on softfloat-hs, which in turn depends on the
-softfloat library.  If you are not building `macaw-riscv` you can skip this
-step.  To install softfloat on Linux or OSX, run:
+softfloat library.  Macaw's build system will automatically build softfloat,
+but the softfloat-hs repo must be recursively cloned to enable this.  If you
+are not building `macaw-riscv` you can skip this step.  To recursively clone
+softfloat, run:
 ```shell
 $ cd deps/softfloat-hs
 $ git submodule update --init --recursive
-$ make
-$ sudo make install
 ```
-
-The Makefile in `deps/softfloat-hs` should install the softfloat library and
-header files to the appropriate locations on both OSX and Linux.
 
 ## Building with Cabal
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The RISC-V backend depends on softfloat-hs, which in turn depends on the
 softfloat library.  Macaw's build system will automatically build softfloat,
 but the softfloat-hs repo must be recursively cloned to enable this.  If you
 are not building `macaw-riscv` you can skip this step.  To recursively clone
-softfloat, run:
+softfloat-hs, run:
 ```shell
 $ cd deps/softfloat-hs
 $ git submodule update --init --recursive


### PR DESCRIPTION
This PR updates the softfloat-hs submodule to a version that doesn't require a manual `make` and `make install` over the softfloat library.