### PR TITLE
[symbolic] Optimize how initial binary memories are populated

### DIFF
--- a/refinement/src/Data/Macaw/Refinement/SymbolicExecution.hs
+++ b/refinement/src/Data/Macaw/Refinement/SymbolicExecution.hs
@@ -468,13 +468,14 @@ extractIPModels ctx bak solverProc initialAssumptions res_ip_base res_ip_off = d
       nModels | nModels == modelMax -> return SpuriousModels
               | otherwise -> return (Models resolved)
 
-initializeSimulator :: forall m sym bak arch blocks ids tp
+initializeSimulator :: forall m sym bak arch blocks ids tp t st fs
                      . ( MonadIO m
                        , 16 <= M.ArchAddrWidth arch
                        , MS.SymArchConstraints arch
                        , CB.IsSymBackend sym bak
                        , LLVM.HasLLVMAnn sym
                        , Show (W.SymExpr sym (W.BaseBVType (M.ArchAddrWidth arch)))
+                       , sym ~ WE.ExprBuilder t st fs
                        , ?memOpts :: LLVM.MemOptions
                        )
                     => RefinementContext arch

--- a/symbolic/ChangeLog.md
+++ b/symbolic/ChangeLog.md
@@ -6,6 +6,8 @@
 
 ### API Changes
 
+- The `newGlobalMemory` and `newGlobalMemoryWith` functions now requires that `sym ~ ExprBuilder` due to some optimizations in populating the initial memory contents of large binaries
+
 - The types of various functions, such as `macawExtensions`, are now parametric
   over the `personality` type variable instead of restricting it to
   `MacawSimulatorState sym`. A consequence of this change is that the


### PR DESCRIPTION
Before, the API provided by macaw-symbolic asserted the initial value of each byte of memory individually. This was fairly expensive for large binaries, as each such assertion flushed the solver pipe.

This change generates a large conjunction of assertions and sends them all at once. In unscientific testing, this saved half an hour on a large binary.

API Changes:

- Note that it introduces a minor API change. The optimization required that the `sym` parameter be concretely an `ExprBuilder`.