### PR TITLE
Export an extra function from the discovery API

### DIFF
--- a/base/src/Data/Macaw/Discovery.hs
+++ b/base/src/Data/Macaw/Discovery.hs
@@ -36,6 +36,7 @@ module Data.Macaw.Discovery
        , Data.Macaw.Discovery.analyzeFunction
        , Data.Macaw.Discovery.analyzeDiscoveredFunctions
        , Data.Macaw.Discovery.addDiscoveredFunctionBlockTargets
+       , Data.Macaw.Discovery.discoverFunction
          -- * Top level utilities
        , Data.Macaw.Discovery.completeDiscoveryState
        , Data.Macaw.Discovery.incCompleteDiscovery


### PR DESCRIPTION
This is necessary to implement custom logic using the incremental computation
monad, as the even lower-level infrastructure is not exposed at all.