### PR TITLE
Adapt to `dynSymEntry` being definition-aware in `elf-edit`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,15 @@ name: CI
 on:
   push:
 
+# The CACHE_VERSION can be updated to force the use of a new cache if
+# the current cache contents become corrupted/invalid.  This can
+# sometimes happen when (for example) the OS version is changed but
+# older .so files are cached, which can have various effects
+# (e.g. cabal complains it can't find a valid version of the "happy"
+# tool).
+env:
+  CACHE_VERSION: 1
+
 jobs:
   build-linux:
 
@@ -40,9 +49,9 @@ jobs:
       with:
         path: /home/runner/.cabal/store/ghc-${{ matrix.ghc-ver }}
         # Prefer previous SHA hash if it is still cached
-        key: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        key: ${{ env.CACHE_VERSION }}-linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
         # otherwise just use most recent build.
-        restore-keys: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: ${{ env.CACHE_VERSION }}-linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}
 
     - name: System Dependencies
       run: |

--- a/base/ChangeLog.md
+++ b/base/ChangeLog.md
@@ -18,3 +18,6 @@
 
   It is recommended that future references to these types be done through this module. They are re-exported from their original location (`Data.Macaw.Discovery.State`) for backwards compatibility. One day that is likely to change.
 
+- The `DynamicSymbolTable` constructor of `Data.Macaw.Memory.ElfLoader`'s
+  `SymbolTable` data type now has an additional `VersionDefMap` field, which is
+  needed for finding versioning information in some cases.


### PR DESCRIPTION
This bump the `elf-edit` submodule to bring in the changes from GaloisInc/elf-edit#29, which adds an additional `VersionDefMap` argument to `elf-edit` to make it aware of version definitions. This requires some changes to the API in `Data.Macaw.Memory.ElfLoader` to accommodate.