### PR TITLE
Reverse syscall override return register ordering

### DIFF
--- a/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
@@ -644,7 +644,9 @@ a32InstructionMatcher (ARMDis.Instruction opc operands) =
                                  <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R6"))
                                  <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R7"))
             res <- G.addExpr =<< evalArchFn sc
-            -- res is a tuple of form (R1, R0)
+            -- res is a tuple of form (R1, R0).  This is reversed from the
+            -- user provided return Assignment of empty :> R0 :> R1 because
+            -- the conversion from Assignment to Tuple reversed the order.
             G.setRegVal r1 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index0))
             G.setRegVal r0 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index1))
 

--- a/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
@@ -699,7 +699,9 @@ t32InstructionMatcher (ThumbDis.Instruction opc operands) =
                                    <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R6"))
                                    <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R7"))
             res <- G.addExpr =<< evalArchFn sc
-            -- res is a tuple of form (R1, R0)
+            -- res is a tuple of form (R1, R0).  This is reversed from the
+            -- user provided return Assignment of empty :> R0 :> R1 because
+            -- the conversion from Assignment to Tuple reversed the order.
             G.setRegVal r1 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index0))
             G.setRegVal r0 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index1))
 

--- a/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Arch.hs
@@ -644,8 +644,9 @@ a32InstructionMatcher (ARMDis.Instruction opc operands) =
                                  <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R6"))
                                  <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R7"))
             res <- G.addExpr =<< evalArchFn sc
-            G.setRegVal r0 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index0))
-            G.setRegVal r1 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index1))
+            -- res is a tuple of form (R1, R0)
+            G.setRegVal r1 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index0))
+            G.setRegVal r0 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index1))
 
             -- Increment the PC; we don't get the normal PC increment from the
             -- ASL semantics, since we are intercepting them to just add this statement
@@ -698,8 +699,9 @@ t32InstructionMatcher (ThumbDis.Instruction opc operands) =
                                    <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R6"))
                                    <*> G.getRegVal (ARMReg.ARMGlobalBV (ASL.knownGlobalRef @"_R7"))
             res <- G.addExpr =<< evalArchFn sc
-            G.setRegVal r0 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index0))
-            G.setRegVal r1 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index1))
+            -- res is a tuple of form (R1, R0)
+            G.setRegVal r1 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index0))
+            G.setRegVal r0 =<< G.addExpr (G.AppExpr (MC.TupleField PC.knownRepr res PL.index1))
 
             -- Increment the PC; we don't get the normal PC increment from the
             -- ASL semantics, since we are intercepting them to just add this statement

--- a/macaw-riscv/src/Data/Macaw/RISCV/Disassemble.hs
+++ b/macaw-riscv/src/Data/Macaw/RISCV/Disassemble.hs
@@ -340,7 +340,9 @@ disStmt opcode stmt = do
                                      <*> getReg GPR_A6
                                      <*> getReg GPR_A7
       res <- evalArchFn ec
-      -- res is a tuple of form (A1, A0)
+      -- res is a tuple of form (A1, A0).  This is reversed from the user
+      -- provided return Assignment of empty :> A0 :> A1 because the conversion
+      -- from Assignment to Tuple reversed the order.
       setReg GPR_A1 =<< evalApp (MC.TupleField knownRepr res L.index0)
       setReg GPR_A0 =<< evalApp (MC.TupleField knownRepr res L.index1)
     _ -> return ()

--- a/macaw-riscv/src/Data/Macaw/RISCV/Disassemble.hs
+++ b/macaw-riscv/src/Data/Macaw/RISCV/Disassemble.hs
@@ -340,8 +340,9 @@ disStmt opcode stmt = do
                                      <*> getReg GPR_A6
                                      <*> getReg GPR_A7
       res <- evalArchFn ec
-      setReg GPR_A0 =<< evalApp (MC.TupleField knownRepr res L.index0)
-      setReg GPR_A1 =<< evalApp (MC.TupleField knownRepr res L.index1)
+      -- res is a tuple of form (A1, A0)
+      setReg GPR_A1 =<< evalApp (MC.TupleField knownRepr res L.index0)
+      setReg GPR_A0 =<< evalApp (MC.TupleField knownRepr res L.index1)
     _ -> return ()
   F.traverse_ disAssignStmt (collapseStmt stmt)
 

--- a/x86/src/Data/Macaw/X86/Generator.hs
+++ b/x86/src/Data/Macaw/X86/Generator.hs
@@ -356,8 +356,9 @@ addArchSyscall :: X86Generator st_s ids ()
 addArchSyscall = do
   sc <- X86Syscall (knownNat @64) <$> getRegValue RAX <*> getRegValue RDI <*> getRegValue RSI <*> getRegValue RDX <*> getRegValue R10 <*> getRegValue R8 <*> getRegValue R9
   res <- evalArchFn sc
-  setReg RAX =<< eval (app (TupleField knownRepr res PL.index0))
-  setReg RDX =<< eval (app (TupleField knownRepr res PL.index1))
+  -- res is a tuple of form (RDX, RAX)
+  setReg RDX =<< eval (app (TupleField knownRepr res PL.index0))
+  setReg RAX =<< eval (app (TupleField knownRepr res PL.index1))
   addTermStmt FetchAndExecute
 
 -- | execute a primitive instruction.

--- a/x86/src/Data/Macaw/X86/Generator.hs
+++ b/x86/src/Data/Macaw/X86/Generator.hs
@@ -356,7 +356,9 @@ addArchSyscall :: X86Generator st_s ids ()
 addArchSyscall = do
   sc <- X86Syscall (knownNat @64) <$> getRegValue RAX <*> getRegValue RDI <*> getRegValue RSI <*> getRegValue RDX <*> getRegValue R10 <*> getRegValue R8 <*> getRegValue R9
   res <- evalArchFn sc
-  -- res is a tuple of form (RDX, RAX)
+  -- res is a tuple of form (RDX, RAX).  This is reversed from the user
+  -- provided return Assignment of empty :> RAX :> RDX because the conversion
+  -- from Assignment to Tuple reversed the order.
   setReg RDX =<< eval (app (TupleField knownRepr res PL.index0))
   setReg RAX =<< eval (app (TupleField knownRepr res PL.index1))
   addTermStmt FetchAndExecute


### PR DESCRIPTION
When a user overrides a system call on an architecture that supports returning two values from a system call and they provide a context containing the result of the system call in the form

```
empty :> v0 :> v1
```

macaw will perform the register assignment

```
r0 := v1
r1 := v0
```

This change reverses this behavior so that the assignment becomes

```
r0 := v0
r1 := v1
```

This brings the expected ordering of the result context in agreement
with the left-to-right ordering of the argument context:

```
empty :> arg1 :> arg2 :> ...
```