### PR TITLE
`macaw-symbolic`: Include addresses in `populateRelocation`

### DIFF
--- a/symbolic/ChangeLog.md
+++ b/symbolic/ChangeLog.md
@@ -38,6 +38,10 @@
   - `Data.Macaw.Symbolic.Memory.newGlobalMemory`
   - `Data.Macaw.Symbolic.MemOps.{doWriteMem,doCondWriteMem}`
 
+- The type of `populateRelocation` has gained three additional arguments—the
+  `Memory`, `MemSegment`, and `MemAddr` corresponding to the relocation—to
+  more easily facilitate computing the address of the relocation.
+
 ### Behavioral Changes
 
 - Redundant pointer validity checks have been removed from `doReadMem`, `doCondReadMem`, `doWriteMem`, and `doCondWriteMem`; this should be mostly invisible to library clients unless they rely on goal counts or goal numbers


### PR DESCRIPTION
When populating `COPY` relocations, it is helpful to know the address of the relocation so that it can be related back to the name of the global symbol whose value it is copying. Unfortunately, the type of `populateRelocation` does not make it straightforward to compute this address. This patch includes three additional arguments to `populateRelocation` (the relocation's `Memory`, its `MemSegment`, and its `MemAddr`) to more easily facilitate computing the address.

This is a breaking API change, albet it is a fairly straightforward change to adapt to for most consumers.

This is related to #47, although this is not a full fix for the issue.