### PR TITLE
workaround for IntervalMap empty intersections

### DIFF
--- a/base/src/Data/Macaw/Memory/ElfLoader.hs
+++ b/base/src/Data/Macaw/Memory/ElfLoader.hs
@@ -1181,6 +1181,8 @@ insertElfSegment regIdx addrOff shdrMap contents relocMap phdr = do
     mlsMemory %= memBindSegmentIndex segIdx seg
     -- Iterative through sections
     let interval = IntervalCO phdrOffset phdrEnd
+    -- Workaround for https://github.com/bokesan/IntervalMap/issues/9, where 'IMap.intersecting' can return
+    -- nonempty results when given an empty interval.
     let l = if IMap.isEmpty interval then [] else IMap.toList $ IMap.intersecting shdrMap interval
     forM_ l $ \(i, elfIdx) -> do
       case i of

--- a/base/src/Data/Macaw/Memory/ElfLoader.hs
+++ b/base/src/Data/Macaw/Memory/ElfLoader.hs
@@ -58,6 +58,7 @@ import qualified Data.ElfEdit.Prim as Elf
 import           Data.Foldable
 import           Data.IntervalMap.Strict (Interval(..), IntervalMap)
 import qualified Data.IntervalMap.Strict as IMap
+import qualified Data.IntervalMap.Generic.Strict as IMap
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
@@ -1179,7 +1180,8 @@ insertElfSegment regIdx addrOff shdrMap contents relocMap phdr = do
     -- Add segment index to address mapping to memory object.
     mlsMemory %= memBindSegmentIndex segIdx seg
     -- Iterative through sections
-    let l = IMap.toList $ IMap.intersecting shdrMap (IntervalCO phdrOffset phdrEnd)
+    let interval = IntervalCO phdrOffset phdrEnd
+    let l = if IMap.isEmpty interval then [] else IMap.toList $ IMap.intersecting shdrMap interval
     forM_ l $ \(i, elfIdx) -> do
       case i of
         IntervalCO shdr_start _ -> do


### PR DESCRIPTION
The function IntervalMap.intersecting is incorrectly returning nonempty results when given an empty interval. This works around the issue by explicitly adding an isEmpty check.

This resolves an issue where ElfLoader would error, saying "Found section header that overlaps with program header.", if presented with a segment that has zero file size.