### PR TITLE
support hashable-1.4

### DIFF
--- a/base/ChangeLog.md
+++ b/base/ChangeLog.md
@@ -21,3 +21,7 @@
 - The `DynamicSymbolTable` constructor of `Data.Macaw.Memory.ElfLoader`'s
   `SymbolTable` data type now has an additional `VersionDefMap` field, which is
   needed for finding versioning information in some cases.
+
+- The `Hashable` and `HashableF` instances for `App f` now require
+  `TestEquality f` constraints. (This is needed to support `hashable-1.4.*`,
+  which adds `Eq` as a superclass to `Hashable`.)

--- a/base/src/Data/Macaw/CFG/App.hs
+++ b/base/src/Data/Macaw/CFG/App.hs
@@ -385,7 +385,7 @@ instance TestEquality f => TestEquality (App f) where
                    ]
                   )
 
-instance HashableF f => Hashable (App f tp) where
+instance (HashableF f, TestEquality f) => Hashable (App f tp) where
   hashWithSalt = $(structuralHashWithSalt [t|App|]
                      [ (DataArg 0 `TypeApp` AnyType, [|hashWithSaltF|])
                      , (ConType [t|TypeRepr|] `TypeApp` AnyType, [|\s _c -> s|])
@@ -398,7 +398,7 @@ instance HashableF f => Hashable (App f tp) where
                      ]
                   )
 
-instance HashableF f => HashableF (App f) where
+instance (HashableF f, TestEquality f) => HashableF (App f) where
   hashWithSaltF = hashWithSalt
 
 instance OrdF f => OrdF (App f) where

--- a/base/src/Data/Macaw/CFG/AssignRhs.hs
+++ b/base/src/Data/Macaw/CFG/AssignRhs.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -138,6 +137,9 @@ instance TestEquality MemRepr where
     Refl <- testEquality xe ye
     Just Refl
   testEquality _ _ = Nothing
+
+instance Eq (MemRepr tp) where
+  a == b = isJust (testEquality a b)
 
 instance Hashable (MemRepr tp) where
   hashWithSalt s mr =

--- a/base/src/Data/Macaw/CFG/Core.hs
+++ b/base/src/Data/Macaw/CFG/Core.hs
@@ -239,6 +239,9 @@ instance TestEquality (CValue arch) where
     if x == y then Just Refl else Nothing
   testEquality _ _ = Nothing
 
+instance Eq (CValue arch tp) where
+  a == b = isJust (testEquality a b)
+
 instance OrdF (CValue arch) where
   compareF (BoolCValue x) (BoolCValue y) = fromOrdering (compare x y)
   compareF BoolCValue{} _ = LTF

--- a/base/src/Data/Macaw/Types.hs
+++ b/base/src/Data/Macaw/Types.hs
@@ -98,6 +98,8 @@ data FloatInfoRepr (fi :: FloatInfo) where
   QuadFloatRepr   :: FloatInfoRepr QuadFloat
   X86_80FloatRepr :: FloatInfoRepr X86_80Float
 
+deriving instance Eq (FloatInfoRepr fi)
+
 instance KnownRepr FloatInfoRepr HalfFloat where
   knownRepr = HalfFloatRepr
 instance KnownRepr FloatInfoRepr SingleFloat where


### PR DESCRIPTION
Either we want to put an explicit upper bound on hashable (which is currently not explicitly listed, but is depended upon transitively via parameterized-utils re-exporting `Hashable` in `Data.Parameterized.Classes`), or we can sprinkle in a couple of `Eq` instances like so.

Not sure who to review this, but since @RyanGlScott you've been doing such changes elsewhere, maybe you have an opinion on this!