### PR TITLE
bump obsolete CI actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,11 +33,11 @@ jobs:
     name: Macaw - GHC v${{ matrix.ghc-ver }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       id: setup-haskell
       name: Setup Haskell
       with:


### PR DESCRIPTION
I pushed before the previous GHC 8.10.7 built finished, so it's lagging behind, but looks like this works!