### PR TITLE
make error casing uniform

### DIFF
--- a/base/src/Data/Macaw/Discovery/Classifier.hs
+++ b/base/src/Data/Macaw/Discovery/Classifier.hs
@@ -362,7 +362,7 @@ noreturnCallParsedContents bcc =
 --
 -- Note that this classifier should always be run before the 'callClassifier'.
 noreturnCallClassifier :: BlockClassifier arch ids
-noreturnCallClassifier = classifierName "no return call" $ do
+noreturnCallClassifier = classifierName "No return call" $ do
   bcc <- CMR.ask
   let ctx = classifierParseContext bcc
   -- Check for tail call when the calling convention seems to be satisfied.


### PR DESCRIPTION
This was the only classifier error message not capitalized.