### PR TITLE
`macaw-ppc`: Don't assume absolute IP addresses when decoding

### DIFF
--- a/macaw-aarch32/src/Data/Macaw/ARM/Disassemble.hs
+++ b/macaw-aarch32/src/Data/Macaw/ARM/Disassemble.hs
@@ -331,7 +331,6 @@ data TranslationError w = TranslationError { transErrorAddr :: MM.MemSegmentOff 
 data TranslationErrorReason w = InvalidNextPC (MM.MemAddr w) (MM.MemAddr w)
                               | DecodeError (ARMMemoryError w)
                               | UnsupportedInstruction InstructionSet
-                              | InstructionAtUnmappedAddr InstructionSet
                               | GenerationError InstructionSet SG.GeneratorError
                               deriving (Show)
 

--- a/macaw-ppc/src/Data/Macaw/PPC/Disassemble.hs
+++ b/macaw-ppc/src/Data/Macaw/PPC/Disassemble.hs
@@ -252,7 +252,6 @@ data TranslationError w = TranslationError { transErrorAddr :: MM.MemSegmentOff 
 data TranslationErrorReason w = InvalidNextIP Word64 Word64
                               | DecodeError (PPCMemoryError w)
                               | UnsupportedInstruction D.Instruction
-                              | InstructionAtUnmappedAddr D.Instruction
                               | GenerationError D.Instruction GeneratorError
                               deriving (Show)
 


### PR DESCRIPTION
`macaw-ppc` was previously assuming that addresses are absolute, which is not true for position independent executables. Extracting the offset from the address is sufficient for our purposes here (note that taking the offset from the `MemSegmentOffset` would not be right, as that offset is relative to the segment start).

This is the exact same issue that was noticed in https://github.com/GaloisInc/macaw/commit/37d8029c00d99335625ab615c7ae94fba18f9574 (in `macaw-aarch32`), but that commit forgot to fix things on the `macaw-ppc` end.