### PR TITLE
derive `Show` for `FunctionArgAnalysisFailure`

### DIFF
--- a/base/src/Data/Macaw/Analysis/FunctionArgs.hs
+++ b/base/src/Data/Macaw/Analysis/FunctionArgs.hs
@@ -356,6 +356,7 @@ data FunctionArgAnalysisFailure w
      -- ^ Could not determine call arguments.
    | PLTStubNotSupported
      -- ^ PLT stub analysis not supported.
+  deriving (Show)
 
 -- | Monad that runs for computing the dependcies of each block.
 type FunctionArgsM arch ids =


### PR DESCRIPTION
It's sometimes practical to debug the map of analysis failures by printing them all out, but we don't seem to have any facilities for printing them.