### PR TITLE
Generalize lazy memory model using `HasMacawLazySimulatorState`

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -133,6 +133,7 @@ module Data.Macaw.Symbolic
   , MO.MacawSimulatorState(..)
   , MO.MacawLazySimulatorState(..)
   , MO.emptyMacawLazySimulatorState
+  , MO.HasMacawLazySimulatorState(..)
   , MO.populatedMemChunks
   , MkGlobalPointerValidityAssertion
   , MemModelConfig(..)

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
@@ -100,8 +100,8 @@ import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 -- Note some key differences between this function and the @memModelConfig@
 -- function in "Data.Macaw.Symbolic.Memory":
 --
--- * This function requires the personality type to be
---   'MS.MacawLazySimulatorState', as it must track which sections of global
+-- * This function requires the personality type to be an instance of
+--   'MS.HasMacawLazySimulatorState', as it must track which sections of global
 --   memory have already been populated in the simulator state.
 --
 -- * This function requires an 'CBO.OnlineBackend' to make use of an online
@@ -112,6 +112,7 @@ memModelConfig ::
      , sym ~ WE.ExprBuilder scope st fs
      , bak ~ CBO.OnlineBackend solver scope st fs
      , WPO.OnlineSolver solver
+     , MS.HasMacawLazySimulatorState p sym w
      , MC.MemWidth w
      , 1 <= w
      , 16 <= w
@@ -120,7 +121,7 @@ memModelConfig ::
      )
   => bak
   -> MemPtrTable sym w
-  -> MS.MemModelConfig (MS.MacawLazySimulatorState sym w) sym arch CL.Mem
+  -> MS.MemModelConfig p sym arch CL.Mem
 memModelConfig bak mpt =
   MS.MemModelConfig
     { MS.globalMemMap = mapRegionPointers mpt
@@ -660,7 +661,7 @@ lazilyPopulateGlobalMemArr ::
   forall sym bak w t st fs p ext.
   ( CB.IsSymBackend sym bak
   , sym ~ WEB.ExprBuilder t st fs
-  , p ~ MS.MacawLazySimulatorState sym w
+  , MS.HasMacawLazySimulatorState p sym w
   , MC.MemWidth w
   ) =>
   bak ->


### PR DESCRIPTION
This introduces a `HasMacawLazySimulatorState` data type, which provides a "classy lens" for accessing a `MacawLazySimulatorState` within some Crucible personality type. It also generalizes the lazy `macaw-symbolic` memory model in `Data.Macaw.Symbolic.Memory.Lazy` to be polymorphic over `HasMacawLazySimulatorState` instances. The upside is that it is now possible to use the lazy memory model at other personality types besides just `MacawLazySimulatorState`, making it much easier to extend the memory model.

Because there is a `HasMacawLazySimulatorState` instance for `MacawLazySimulatorState`, existing code that uses `MacawLazySimulatorState` should continue to compile without changes.

Fixes #357.