### PR TITLE
add ShowF instance for FloatInfoRepr

### DIFF
--- a/base/src/Data/Macaw/Types.hs
+++ b/base/src/Data/Macaw/Types.hs
@@ -130,6 +130,8 @@ instance Show (FloatInfoRepr fi) where
   show QuadFloatRepr   = "quad"
   show X86_80FloatRepr = "x87_80"
 
+instance ShowF FloatInfoRepr where
+
 instance Pretty (FloatInfoRepr fi) where
   pretty = viaShow
 


### PR DESCRIPTION
Makes it possible to derive a `Show` instance for a datatype including a `Some FloatInfoRepr`.