### PR TITLE
bump CI actions versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,11 +33,11 @@ jobs:
     name: Macaw - GHC v${{ matrix.ghc-ver }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell
       name: Setup Haskell
       with:
@@ -67,7 +67,7 @@ jobs:
 
     # WARNING: Make sure this step remains after the step that creates
     # cabal.project.freeze, or the cache key will be incorrect!
-    - uses: actions/cache/restore@v3
+    - uses: actions/cache/restore@v4
       name: Restore cabal store cache
       with:
         path: |
@@ -145,7 +145,7 @@ jobs:
     - name: Build compare-dwarfdump
       run: cabal build compare-dwarfdump
 
-    - uses: actions/cache/save@v3
+    - uses: actions/cache/save@v4
       name: Save cabal store cache
       if: always()
       with:


### PR DESCRIPTION
Looks like all CI actions succeeded. No more warnings.