### PR TITLE
parse subroutine type declaration formal parameters

### DIFF
--- a/base/ChangeLog.md
+++ b/base/ChangeLog.md
@@ -32,3 +32,6 @@
 - The `Hashable` and `HashableF` instances for `App f` now require
   `TestEquality f` constraints. (This is needed to support `hashable-1.4.*`,
   which adds `Eq` as a superclass to `Hashable`.)
+
+- `SubroutineTypeDecl` now contains a parsed `Variable` (rather than an unparsed `DIE`) for its
+  formals.

--- a/base/src/Data/Macaw/Dwarf.hs
+++ b/base/src/Data/Macaw/Dwarf.hs
@@ -630,7 +630,7 @@ data EnumDecl = EnumDecl
 
 data SubroutineTypeDecl = SubroutineTypeDecl
   { fntypePrototyped :: !(Maybe Bool),
-    fntypeFormals :: ![DIE],
+    fntypeFormals :: ![Variable],
     fntypeType :: !(Maybe TypeRef)
   }
   deriving (Show)
@@ -837,9 +837,9 @@ parseEnumerationType fileVec = do
 
 -- | Parse a subroutine type.
 parseSubroutineType :: TypeParser
-parseSubroutineType _ = do
+parseSubroutineType fileVec = do
   proto <- getMaybeAttribute DW_AT_prototyped attributeAsBool
-  formals <- parseChildrenList DW_TAG_formal_parameter pure
+  formals <- parseParameters fileVec
 
   tp <- getMaybeAttribute DW_AT_type attributeAsTypeRef
 


### PR DESCRIPTION
This is useful for Reopt as we want to get more accurate type information for library functions.

Is this acceptable for other clients?