### PR TITLE
expose `memInt` in `Memory`

### DIFF
--- a/base/src/Data/Macaw/Memory.hs
+++ b/base/src/Data/Macaw/Memory.hs
@@ -64,6 +64,7 @@ module Data.Macaw.Memory
   , addrRead
     -- * MemInt
   , MemInt
+  , memInt
   , memIntValue
     -- * Addresses
   , MemAddr(..)


### PR DESCRIPTION
A future fix I'm going to submit would benefit from having this exposed, and we believe this to be a good idea regardless.