### PR TITLE
add a `Bits` instance to `MemInt`

### DIFF
--- a/base/src/Data/Macaw/Memory.hs
+++ b/base/src/Data/Macaw/Memory.hs
@@ -465,6 +465,20 @@ instance MemWidth w => Integral (MemInt w) where
     where (q,r) = memIntValue x `quotRem` memIntValue y
   toInteger = toInteger . memIntValue
 
+instance MemWidth w => Bits (MemInt w) where
+  MemInt x .&. MemInt y = memInt (x .&. y)
+  MemInt x .|. MemInt y = memInt (x .|. y)
+  MemInt x `xor` MemInt y = memInt (x `xor` y)
+  complement (MemInt x) = memInt (complement x)
+  MemInt x `shift` i = memInt (x `shift` i)
+  MemInt x `rotate` i = memInt (x `rotate` i)
+  bitSize = addrBitSize
+  bitSizeMaybe x = Just (addrBitSize x)
+  isSigned _ = True
+  MemInt x `testBit` i = x `testBit` i
+  bit i = memInt (bit i)
+  popCount (MemInt x) = popCount x
+
 ------------------------------------------------------------------------
 -- Relocation
 


### PR DESCRIPTION
Note: this made me realize that `addrBitSize` is a bit ill-named as I don't think it has anything to do with addresses.