### PR TITLE
symbolic: Factor stack setup code into its own module

### DIFF
--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -39,6 +39,7 @@ library
     Data.Macaw.Symbolic.Memory
     Data.Macaw.Symbolic.Memory.Lazy
     Data.Macaw.Symbolic.MemOps
+    Data.Macaw.Symbolic.Stack
     Data.Macaw.Symbolic.Testing
   other-modules:
     Data.Macaw.Symbolic.Bitcast

--- a/symbolic/src/Data/Macaw/Symbolic/Stack.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Stack.hs
@@ -15,11 +15,8 @@ module Data.Macaw.Symbolic.Stack
   ) where
 
 import Data.BitVector.Sized qualified as BVS
-import Data.Macaw.CFG qualified as MC
-import Data.Macaw.Symbolic qualified as MS
 import Data.Parameterized.Context as Ctx
 import Lang.Crucible.Backend qualified as C
-import Lang.Crucible.Simulator qualified as C
 import Lang.Crucible.LLVM.DataLayout qualified as CLD
 import Lang.Crucible.LLVM.MemModel qualified as CLM
 import What4.Interface qualified as WI
@@ -116,14 +113,3 @@ createArrayStack bak mem slots sz = do
   top <- CLM.ptrSub sym ?ptrWidth end slotsBytesBv
 
   pure (ArrayStack base top arr, mem2)
-
--- | Set the stack pointer register.
-_setStackPointerReg ::
-  1 WI.<= MC.ArchAddrWidth arch =>
-  MS.SymArchConstraints arch =>
-  C.IsSymInterface sym =>
-  MS.ArchVals arch ->
-  C.RegEntry sym (MS.ArchRegStruct arch) ->
-  CLM.LLVMPtr sym (MC.ArchAddrWidth arch) ->
-  C.RegEntry sym (MS.ArchRegStruct arch)
-_setStackPointerReg archVals regs = MS.updateReg archVals regs MC.sp_reg

--- a/symbolic/src/Data/Macaw/Symbolic/Stack.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Stack.hs
@@ -27,8 +27,6 @@ stackAlign :: CLD.Alignment
 stackAlign = CLD.noAlignment
 
 -- | Create an SMT array representing the program stack.
---
--- Builds a 'WI.freshConstant' with name "stack_array".
 stackArray ::
   (1 WI.<= w) =>
   CLM.HasPtrWidth w =>
@@ -69,7 +67,7 @@ newtype ExtraStackSlots = ExtraStackSlots { getExtraStackSlots :: Int }
   -- optparse-applicative-based command-line parsers using the `Read` instance.
   deriving newtype (Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
--- | An allocartion representing the program stack, backed by an SMT array
+-- | An allocation representing the program stack, backed by an SMT array
 data ArrayStack sym w
   = ArrayStack
     { -- | Pointer to the base of the stack array

--- a/symbolic/src/Data/Macaw/Symbolic/Stack.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Stack.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Data.Macaw.Symbolic.Stack
+  ( stackArray
+  , mallocStack
+  , ArrayStack(..)
+  , createArrayStack
+  ) where
+
+import Data.Parameterized.Context as Ctx
+
+import qualified What4.Interface as WI
+import qualified What4.Symbol as WSym
+
+import qualified Lang.Crucible.Backend as C
+
+import qualified Lang.Crucible.LLVM.DataLayout as CLD
+import qualified Lang.Crucible.LLVM.MemModel as CLM
+
+-- | Helper, not exported
+stackAlign :: CLD.Alignment
+stackAlign = CLD.noAlignment
+
+-- | Create an SMT array representing the program stack.
+--
+-- Builds a 'WI.freshConstant' with name "stack_array".
+stackArray ::
+  (1 WI.<= w) =>
+  CLM.HasPtrWidth w =>
+  WI.IsSymExprBuilder sym =>
+  sym ->
+  IO (WI.SymArray sym (Ctx.SingleCtx (WI.BaseBVType w)) (WI.BaseBVType 8))
+stackArray sym =
+  WI.freshConstant
+    sym
+    (WSym.safeSymbol "stack_array")
+    (WI.BaseArrayRepr (Ctx.singleton (WI.BaseBVRepr ?ptrWidth)) WI.knownRepr)
+
+-- | Create an allocation representing the program stack, using 'CLM.doMalloc'.
+--
+-- This allocation is:
+--
+-- * mutable, because the program must write to the stack
+-- * of kind 'CLM.StackAlloc'
+-- * without alignment ('CLD.noAlignment')
+mallocStack ::
+  C.IsSymBackend sym bak =>
+  CLM.HasPtrWidth w =>
+  (?memOpts :: CLM.MemOptions) =>
+  CLM.HasLLVMAnn sym =>
+  bak ->
+  CLM.MemImpl sym ->
+  -- | Size of stack allocation
+  WI.SymExpr sym (WI.BaseBVType w) ->
+  IO (CLM.LLVMPtr sym w, CLM.MemImpl sym)
+mallocStack bak mem sz =
+  CLM.doMalloc bak CLM.StackAlloc CLM.Mutable "stack_alloc" mem sz stackAlign
+
+data ArrayStack sym w
+  = ArrayStack
+    { -- | Pointer to the base of the stack array
+      arrayStackPtr :: CLM.LLVMPtr sym w
+      -- | SMT array backing the stack allocation
+    , arrayStackVal :: WI.SymArray sym (Ctx.SingleCtx (WI.BaseBVType w)) (WI.BaseBVType 8)
+    }
+
+-- | Create an SMT-array-backed stack allocation
+--
+-- * Creates a stack array with 'stackArray'
+-- * Allocates space for the stack with 'mallocStack'
+-- * Writes the stack array to the allocation
+createArrayStack ::
+  C.IsSymBackend sym bak =>
+  CLM.HasPtrWidth w =>
+  (?memOpts :: CLM.MemOptions) =>
+  CLM.HasLLVMAnn sym =>
+  bak ->
+  CLM.MemImpl sym ->
+  -- | Size of stack allocation
+  WI.SymExpr sym (WI.BaseBVType w) ->
+  IO (ArrayStack sym w, CLM.MemImpl sym)
+createArrayStack bak mem sz = do
+  let sym = C.backendGetSym bak
+  arr <- stackArray sym
+  (ptr, mem1) <- mallocStack bak mem sz
+  mem2 <- CLM.doArrayStore bak mem1 ptr stackAlign arr sz
+  pure (ArrayStack ptr arr, mem2)

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -529,7 +529,7 @@ simulateFunction binfo bak execFeatures archInfo archVals halloc mmPreset g = do
   let mib = 1024 * kib
   stackSize <- WI.bvLit sym WI.knownRepr (BVS.mkBV WI.knownRepr (2 * mib))
   (MSS.ArrayStack stackBasePtr _stackTopPtr _stackArrayStorage, mem1) <-
-    MSS.createArrayStack bak initMem stackSize
+    MSS.createArrayStack bak initMem (MSS.ExtraStackSlots 0) stackSize
 
   -- Make initial registers, including setting up a stack pointer.
   --


### PR DESCRIPTION
Factors some code out of `Testing` into its own module for the sake of clarity and code-sharing. Several downstream projects could benefit from this API, see #430 for examples.

Also, rewrites a comment that I believe to have been misleading.