### PR TITLE
symbolic: Remove redundant unwrapping/rewrapping of register struct

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: lint
+on:
+  push:
+    branches: [master, "release-**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    name: lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - shell: bash
+        run: |
+          curl --location -o hlint.tar.gz \
+            https://github.com/ndmitchell/hlint/releases/download/v3.8/hlint-3.8-x86_64-linux.tar.gz
+          tar xvf hlint.tar.gz
+
+          (cd symbolic/; ../hlint-3.8/hlint src test)

--- a/symbolic/.hlint.yaml
+++ b/symbolic/.hlint.yaml
@@ -1,0 +1,9 @@
+# HLint's default suggestions are opinionated, so we disable all of them by
+# default and enable just a small subset we can agree on.
+
+- ignore: {}  # ignore all
+
+- error:
+    name: Use crucGenRegStructType
+    lhs: "Lang.Crucible.Types.StructRepr (Data.Macaw.Symbolic.CrucGen.crucArchRegTypes x)"
+    rhs: 'Data.Macaw.Symbolic.CrucGen.crucGenRegStructType x'


### PR DESCRIPTION
There was a lot of redundant unwrapping and re-wrapping of the assignment of `TypeRepr`s to the architecture register context into and out of a `StructRepr`. Remove this.

Also, add an hlint configuration file to help avoid this in the future, and a Github Actions workflow to enforce this in CI.