### PR TITLE
`macaw-dump`: Add `entry-points` subcommand

### DIFF
--- a/macaw-dump/macaw-dump.cabal
+++ b/macaw-dump/macaw-dump.cabal
@@ -104,5 +104,6 @@ library
     Data.Macaw.Dump.CLI
     Data.Macaw.Dump.CLIUtils
     Data.Macaw.Dump.Discover
+    Data.Macaw.Dump.EntryPoints
     Data.Macaw.Dump.Memory
     Data.Macaw.Dump.Plt

--- a/macaw-dump/src/Data/Macaw/Dump.hs
+++ b/macaw-dump/src/Data/Macaw/Dump.hs
@@ -11,6 +11,7 @@ import Data.ElfEdit qualified as EE
 import Data.Macaw.Architecture.Info qualified as MAI
 import Data.Macaw.Dump.CLI qualified as MDC
 import Data.Macaw.Dump.Discover qualified as MDD
+import Data.Macaw.Dump.EntryPoints qualified as MDE
 import Data.Macaw.Dump.Memory qualified as MDM
 import Data.Macaw.Dump.Plt qualified as MDP
 import Data.Macaw.CFG qualified as MC
@@ -35,5 +36,6 @@ main archInfo archVals pltStubInfo = do
   cli <- MDC.parseCli
   case MDC.cliCommand cli of
     MDC.CommandDiscover cfg -> MDD.discover archInfo archVals cfg
+    MDC.CommandEntryPoints cfg -> MDE.entryPoints archInfo cfg
     MDC.CommandMemory cfg -> MDM.memory archInfo cfg
     MDC.CommandPlt cfg -> MDP.plt archInfo pltStubInfo cfg

--- a/macaw-dump/src/Data/Macaw/Dump/CLI.hs
+++ b/macaw-dump/src/Data/Macaw/Dump/CLI.hs
@@ -10,12 +10,14 @@ module Data.Macaw.Dump.CLI
 
 import Control.Applicative ((<**>))
 import Data.Macaw.Dump.Discover qualified as MDD
+import Data.Macaw.Dump.EntryPoints qualified as MDE
 import Data.Macaw.Dump.Memory qualified as MDM
 import Data.Macaw.Dump.Plt qualified as MDP
 import Options.Applicative qualified as Opt
 
 data Command
   = CommandDiscover MDD.DiscoverConfig
+  | CommandEntryPoints MDE.EntryPointsConfig
   | CommandMemory MDM.MemoryConfig
   | CommandPlt MDP.PltConfig
 
@@ -24,6 +26,7 @@ command =
   Opt.subparser $
     mconcat
     [ cmdDiscover
+    , cmdEntryPoints
     , cmdMemory
     , cmdPlt
     ]
@@ -33,6 +36,12 @@ command =
     Opt.command
       "discover"
       (Opt.info (CommandDiscover <$> MDD.discoverConfig) (Opt.progDesc "Perform code discovery and print CFGs"))
+
+  cmdEntryPoints :: Opt.Mod Opt.CommandFields Command
+  cmdEntryPoints = do
+    Opt.command
+      "entry-points"
+      (Opt.info (CommandEntryPoints <$> MDE.entryPointsConfig) (Opt.progDesc "Print entry points"))
 
   cmdMemory :: Opt.Mod Opt.CommandFields Command
   cmdMemory = do

--- a/macaw-dump/src/Data/Macaw/Dump/CLIUtils.hs
+++ b/macaw-dump/src/Data/Macaw/Dump/CLIUtils.hs
@@ -3,6 +3,7 @@
 
 module Data.Macaw.Dump.CLIUtils
   ( binOpt
+  , loadOffsetOpt
   , die
   , loadElf
   ) where
@@ -12,12 +13,23 @@ import Data.ElfEdit qualified as EE
 import Data.Macaw.Architecture.Info qualified as MAI
 import Data.Macaw.CFG qualified as MC
 import Data.Macaw.Memory qualified as MM
+import Data.Word (Word64)
 import Options.Applicative qualified as Opt
 import System.Exit qualified as Exit
 import System.IO qualified as IO
 
 binOpt :: Opt.Parser FilePath
 binOpt = Opt.strArgument (Opt.help "filename of binary" <> Opt.metavar "FILENAME" )
+
+loadOffsetOpt :: Opt.Parser Word64
+loadOffsetOpt = Opt.option Opt.auto opts
+  where
+  opts =
+    mconcat
+    [ Opt.long "offset"
+    , Opt.help "base offset at which to load the file"
+    , Opt.showDefault
+    ]
 
 die :: String -> IO a
 die msg = do

--- a/macaw-dump/src/Data/Macaw/Dump/EntryPoints.hs
+++ b/macaw-dump/src/Data/Macaw/Dump/EntryPoints.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Data.Macaw.Dump.EntryPoints
+  ( EntryPointsConfig(..)
+  , entryPointsConfig
+  , entryPoints
+  ) where
+
+import Data.ElfEdit qualified as EE
+import Data.Foldable qualified as F
+import Data.Macaw.Architecture.Info qualified as MAI
+import Data.Macaw.BinaryLoader qualified as Loader
+import Data.Macaw.CFG qualified as MC
+import Data.Macaw.Dump.CLIUtils qualified as MDCU
+import Data.Macaw.Memory qualified as MM
+import Data.Macaw.Memory.LoadCommon qualified as MML
+import Data.Word (Word64)
+import Options.Applicative qualified as Opt
+
+data EntryPointsConfig = EntryPointsConfig
+  { entryPointsLoadOffset :: Maybe Word64
+  , entryPointsBinPath :: FilePath
+  }
+
+entryPointsConfig :: Opt.Parser EntryPointsConfig
+entryPointsConfig =
+  EntryPointsConfig
+  <$> Opt.optional MDCU.loadOffsetOpt
+  <*> MDCU.binOpt
+
+loadOptions :: EntryPointsConfig -> MML.LoadOptions
+loadOptions cfg = MML.LoadOptions { MML.loadOffset = entryPointsLoadOffset cfg }
+
+entryPoints ::
+  forall arch.
+  ( MM.MemWidth (MC.ArchAddrWidth arch)
+  , Loader.BinaryLoader arch (EE.ElfHeaderInfo (MC.ArchAddrWidth arch))
+  ) =>
+  MAI.ArchitectureInfo arch ->
+  EntryPointsConfig ->
+  IO ()
+entryPoints archInfo cfg = do
+  ehi <- MDCU.loadElf archInfo (entryPointsBinPath cfg)
+  let loadOpts = loadOptions cfg
+  loaded <- Loader.loadBinary @arch loadOpts ehi
+  eps <- Loader.entryPoints loaded
+  F.for_ eps print

--- a/macaw-dump/src/Data/Macaw/Dump/Memory.hs
+++ b/macaw-dump/src/Data/Macaw/Dump/Memory.hs
@@ -31,16 +31,6 @@ data MemoryConfig
     , memBinPath :: FilePath
     }
 
-loadOffsetOpt :: Opt.Parser Word64
-loadOffsetOpt = Opt.option Opt.auto opts
-  where
-  opts =
-    mconcat
-    [ Opt.long "offset"
-    , Opt.help "base offset at which to load the file"
-    , Opt.showDefault
-    ]
-
 printContentsOpt :: Opt.Parser Bool
 printContentsOpt = Opt.switch opts
   where
@@ -53,7 +43,7 @@ printContentsOpt = Opt.switch opts
 memoryConfig :: Opt.Parser MemoryConfig
 memoryConfig =
   MemoryConfig
-  <$> Opt.optional loadOffsetOpt
+  <$> Opt.optional MDCU.loadOffsetOpt
   <*> printContentsOpt
   <*> MDCU.binOpt
 


### PR DESCRIPTION
This prints the entry point addresses computed by `macaw-loader`. This proves useful to debug issues like the one observed in https://github.com/GaloisInc/macaw/issues/482.