### PR TITLE
`macaw-loader`: Make `entryPoints` return a possibly empty list

### DIFF
--- a/macaw-loader/src/Data/Macaw/BinaryLoader.hs
+++ b/macaw-loader/src/Data/Macaw/BinaryLoader.hs
@@ -85,7 +85,7 @@ class (MM.MemWidth (MR.ArchAddrWidth arch)) =>
   -- the data returned by this function.
   entryPoints :: (X.MonadThrow m) =>
                  LoadedBinary arch binFmt
-              -> m (NEL.NonEmpty (MM.MemSegmentOff (MM.ArchAddrWidth arch)))
+              -> m (NEL.NonEmpty (MM.ArchSegmentOff arch))
 
   -- | Look up the symbol for the function or global at the given address, if any
   --

--- a/macaw-loader/src/Data/Macaw/BinaryLoader.hs
+++ b/macaw-loader/src/Data/Macaw/BinaryLoader.hs
@@ -16,7 +16,6 @@ import qualified Control.Monad.Catch as X
 import qualified Data.ByteString as BS
 import qualified Data.ElfEdit as E
 import           Data.Kind ( Type )
-import qualified Data.List.NonEmpty as NEL
 import qualified Data.Macaw.CFG as MM
 import qualified Data.Macaw.Memory.LoadCommon as LC
 import qualified Data.Macaw.CFG.AssignRhs as MR
@@ -85,7 +84,7 @@ class (MM.MemWidth (MR.ArchAddrWidth arch)) =>
   -- the data returned by this function.
   entryPoints :: (X.MonadThrow m) =>
                  LoadedBinary arch binFmt
-              -> m (NEL.NonEmpty (MM.ArchSegmentOff arch))
+              -> m [MM.ArchSegmentOff arch]
 
   -- | Look up the symbol for the function or global at the given address, if any
   --

--- a/refinement/tools/Initialization.hs
+++ b/refinement/tools/Initialization.hs
@@ -21,7 +21,6 @@ import qualified Control.Monad.Reader as MR
 import qualified Control.Monad.IO.Unlift as MU
 import qualified Data.ByteString as BS
 import qualified Data.ElfEdit as EE
-import qualified Data.Foldable as F
 import qualified Data.Map as M
 import           Data.Proxy ( Proxy(..) )
 import qualified Lang.Crucible.LLVM.MemModel as LLVM
@@ -89,7 +88,7 @@ withLoadedBinary :: forall arch binFmt m a
                  -> MBL.LoadedBinary arch binFmt
                  -> m a
 withLoadedBinary k archInfo bin = do
-  entries <- F.toList <$> MBL.entryPoints bin
+  entries <- MBL.entryPoints bin
   let dstate0 = MD.cfgFromAddrs archInfo (MBL.memoryImage bin) M.empty entries []
   k (Proxy @arch) archInfo bin dstate0
 
@@ -137,6 +136,6 @@ withRefinedDiscovery opts archInfo bin k = do
                                             , MR.timeoutSeconds = max 1 (timeoutSeconds opts)
                                             }
     ctx <- MR.defaultRefinementContext config bin
-    entries <- F.toList <$> MBL.entryPoints bin
+    entries <- MBL.entryPoints bin
     (dstate, info) <- runRefine @arch $ MR.cfgFromAddrsWith ctx archInfo (MBL.memoryImage bin) M.empty entries []
     k dstate info


### PR DESCRIPTION
It is not guaranteed that an ELF file's `e_entry` value will always correspond to a valid entry point address, which means that we cannot guarantee that the list of entry points that `macaw-loader`'s `entryPoints` computes will always be non-empty. This patch changes the type of `entryPoints` to return `[]` instead of `NonEmpty` and makes it so that failing to resolve the `e_entry` address in `entryPoints` does not throw an exception.

Fixes https://github.com/GaloisInc/macaw/issues/482.