### PR TITLE
`macaw-symbolic`: Fix soundness bug in lazy memory model involving path conditions

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -389,6 +389,7 @@ populateSegmentChunk :: ( 16 <= w
                         , IM.IntervalMap (MC.MemWord w) CL.Mutability
                         )
 populateSegmentChunk _ bak mmc mem symArray seg addr bytes ptrtable = do
+  let sym = CB.backendGetSym bak
   let ?ptrWidth = MC.memWidth mem
   let abs_addr = toAbsoluteAddr addr
   let size = length bytes
@@ -451,7 +452,9 @@ populateSegmentChunk _ bak mmc mem symArray seg addr bytes ptrtable = do
       symArray2 <- liftIO $ WI.arrayUpdateAtIdxLits sym updates symArray
 -}
 
-      MSMC.assumeMemArr bak symArray (toAbsoluteAddr addr) bytes
+      bytesAssmp <-
+        MSMC.memArrEqualityAssumption sym symArray (toAbsoluteAddr addr) bytes
+      liftIO $ CB.addAssumption bak bytesAssmp
       let symArray2 = symArray
 
       return (symArray2, IM.insert interval mut_flag ptrtable)

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
@@ -682,8 +682,10 @@ lazilyPopulateGlobalMemArr bak mpt memRep ptr state
                 -- memory region completely symbolic.
                 not (smcMutability smc == CL.Mutable &&
                      memModelContents mpt == MSMC.SymbolicMutable)
-           then do MSMC.assumeMemArr bak (memPtrArray mpt)
-                     (IMI.lowerBound addr) (smcBytes smc)
+           then do bytesAssmp <-
+                     MSMC.memArrEqualityAssumption sym (memPtrArray mpt)
+                       (IMI.lowerBound addr) (smcBytes smc)
+                   CB.addAssumption bak bytesAssmp
                    pure $ L.over chunksL (IS.insert addr) st
            else pure st
 


### PR DESCRIPTION
Not quite working yet. Although this fixes the test case in #491, it does _not_ fix the corresponding test case from https://github.com/GaloisInc/grease/issues/187.

Towards #491.