### PR TITLE
Remove mentions of non-existent files from macaw-dump

### DIFF
--- a/macaw-dump/macaw-dump.cabal
+++ b/macaw-dump/macaw-dump.cabal
@@ -5,11 +5,8 @@ Author:        Galois Inc.
 Maintainer:    langston@galois.com
 Build-type:    Simple
 License:       BSD-3-Clause
-License-file:  LICENSE
 Category:      Language
 Synopsis:      A tool to display internal Macaw data structures
-
-extra-doc-files: README.md
 
 common shared
   -- Specifying -Wall and -Werror can cause the project to fail to build on


### PR DESCRIPTION
Mentioning these non-existent files breaks cabal-install trying to sdist or install things that depend on this package