### PR TITLE
Add a MacawProcessAssertion implicit callback for recording macaw memory model predicates

### DIFF
--- a/macaw-aarch32-symbolic/tests/Main.hs
+++ b/macaw-aarch32-symbolic/tests/Main.hs
@@ -42,6 +42,7 @@ import qualified Data.Macaw.ARM.ARMReg as MAR
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as M
 import qualified Data.Macaw.Symbolic as MS
+import qualified Data.Macaw.Symbolic.Memory as MS
 import qualified Data.Macaw.Symbolic.Testing as MST
 import qualified What4.Config as WC
 import qualified What4.Expr.Builder as WEB
@@ -191,6 +192,7 @@ setupRegsAndMem ::
   , CCE.IsSyntaxExtension ext
   , CB.IsSymBackend sym bak
   , LLVM.HasLLVMAnn sym
+  , MS.MacawProcessAssertion sym
   , sym ~ WEB.ExprBuilder scope st fs
   , bak ~ CBO.OnlineBackend solver scope st fs
   , WPO.OnlineSolver solver
@@ -273,7 +275,7 @@ symExTestSized expected mmPreset exePath saveSMT saveMacaw step ehi archInfo = d
        MS.withArchConstraints archVals $ do
          halloc <- CFH.newHandleAllocator
          let ?recordLLVMAnnotation = \_ _ _ -> return ()
-
+         let ?processMacawAssert = MS.defaultProcessMacawAssertion
          (regs, iMem) <- setupRegsAndMem bak archVals mmPreset binfo
          (memVar, execResult) <-
            MST.simDiscoveredFunction bak execFeatures archVals halloc iMem regs binfo dfi

--- a/macaw-x86-cli/src/Data/Macaw/X86/Symbolic/CLI.hs
+++ b/macaw-x86-cli/src/Data/Macaw/X86/Symbolic/CLI.hs
@@ -61,6 +61,7 @@ withX86Hooks k = do
       ext bak =  do
         let sym = C.backendGetSym bak
         let ?recordLLVMAnnotation = \_ _ _ -> pure ()
+        let ?processMacawAssert = DMS.ignoreMacawAssertions
         symFns <- newSymFuns sym
         let elfMem = DMC.emptyMemory DMM.Addr64
         let eFn = x86_64MacawEvalFn symFns DMS.defaultMacawArchStmtExtensionOverride

--- a/macaw-x86-cli/src/Data/Macaw/X86/Symbolic/CLI.hs
+++ b/macaw-x86-cli/src/Data/Macaw/X86/Symbolic/CLI.hs
@@ -61,7 +61,7 @@ withX86Hooks k = do
       ext bak =  do
         let sym = C.backendGetSym bak
         let ?recordLLVMAnnotation = \_ _ _ -> pure ()
-        let ?processMacawAssert = DMS.ignoreMacawAssertions
+        let ?processMacawAssert = DMS.defaultProcessMacawAssertion
         symFns <- newSymFuns sym
         let elfMem = DMC.emptyMemory DMM.Addr64
         let eFn = x86_64MacawEvalFn symFns DMS.defaultMacawArchStmtExtensionOverride

--- a/refinement/src/Data/Macaw/Refinement/SymbolicExecution.hs
+++ b/refinement/src/Data/Macaw/Refinement/SymbolicExecution.hs
@@ -189,7 +189,7 @@ smtSolveTransfer ctx slice
         C.SomeCFG cfg -> do
           let executionFeatures = []
           let ?recordLLVMAnnotation = \_ _ _ -> pure ()
-          let ?processMacawAssert = MS.ignoreMacawAssertions
+          let ?processMacawAssert = MS.defaultProcessMacawAssertion
           initialState <- initializeSimulator ctx bak archVals halloc cfg entryBlock
 
           -- Symbolically execute the relevant code in a fresh assumption

--- a/refinement/src/Data/Macaw/Refinement/SymbolicExecution.hs
+++ b/refinement/src/Data/Macaw/Refinement/SymbolicExecution.hs
@@ -189,6 +189,7 @@ smtSolveTransfer ctx slice
         C.SomeCFG cfg -> do
           let executionFeatures = []
           let ?recordLLVMAnnotation = \_ _ _ -> pure ()
+          let ?processMacawAssert = MS.ignoreMacawAssertions
           initialState <- initializeSimulator ctx bak archVals halloc cfg entryBlock
 
           -- Symbolically execute the relevant code in a fresh assumption
@@ -474,6 +475,7 @@ initializeSimulator :: forall m sym bak arch blocks ids tp t st fs
                        , MS.SymArchConstraints arch
                        , CB.IsSymBackend sym bak
                        , LLVM.HasLLVMAnn sym
+                       , MS.MacawProcessAssertion sym
                        , Show (W.SymExpr sym (W.BaseBVType (M.ArchAddrWidth arch)))
                        , sym ~ WE.ExprBuilder t st fs
                        , ?memOpts :: LLVM.MemOptions

--- a/refinement/tests/RefinementTests.hs
+++ b/refinement/tests/RefinementTests.hs
@@ -299,6 +299,7 @@ mkSymbolicTest testinp = do
               (initMem, memPtrTbl) <- MSM.newGlobalMemory proxy bak CLD.LittleEndian MSM.ConcreteMutable mem
               let lookupFn = MS.unsupportedFunctionCalls "macaw-refinement-tests"
               let lookupSC = MS.unsupportedSyscalls "macaw-refinement-tests"
+              let ?processMacawAssert = MSM.defaultProcessMacawAssertion
               let validityCheck _ _ _ _ = return Nothing
               let mmConf = (MSM.memModelConfig bak memPtrTbl)
                              { MS.lookupFunctionHandle = lookupFn

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -126,7 +126,7 @@ module Data.Macaw.Symbolic.Memory (
   MSMC.MemoryModelContents(..),
   MSMC.MacawProcessAssertion,
   MSMC.MacawError(..),
-  MSMC.ignoreMacawAssertions,
+  MSMC.defaultProcessMacawAssertion,
   mkGlobalPointerValidityPred,
   mapRegionPointers
   ) where

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -125,6 +125,7 @@ module Data.Macaw.Symbolic.Memory (
   newMergedGlobalMemoryWith,
   MSMC.MemoryModelContents(..),
   MSMC.MacawProcessAssertion,
+  MSMC.MacawError(..),
   MSMC.ignoreMacawAssertions,
   mkGlobalPointerValidityPred,
   mapRegionPointers

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -124,6 +124,8 @@ module Data.Macaw.Symbolic.Memory (
   newGlobalMemoryWith,
   newMergedGlobalMemoryWith,
   MSMC.MemoryModelContents(..),
+  MSMC.MacawProcessAssertion,
+  MSMC.ignoreMacawAssertions,
   mkGlobalPointerValidityPred,
   mapRegionPointers
   ) where
@@ -174,6 +176,7 @@ memModelConfig ::
      , 16 <= w
      , CL.HasLLVMAnn sym
      , ?memOpts :: CL.MemOptions
+     , MSMC.MacawProcessAssertion sym
      )
   => bak
   -> MemPtrTable sym w
@@ -496,6 +499,7 @@ populateSegmentChunk _ bak mmc mem symArray seg addr bytes ptrtable = do
 mkGlobalPointerValidityPred :: forall sym w
                              . ( CB.IsSymInterface sym
                                , MC.MemWidth w
+                               , MSMC.MacawProcessAssertion sym
                                )
                             => MemPtrTable sym w
                             -> MS.MkGlobalPointerValidityAssertion sym w

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -50,7 +50,6 @@ import qualified What4.Expr.Builder as WEB
 import qualified What4.Interface as WI
 
 import qualified Data.Macaw.Symbolic as MS
-import Debug.Trace (trace)
 
 -- | A configuration knob controlling how the initial contents of the memory
 -- model are populated
@@ -129,7 +128,7 @@ type MacawProcessAssertion sym
 
 
 ignoreMacawAssertions :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym)
-ignoreMacawAssertions _ p _  = trace "Processing with ignore macaw assertion"  (pure p)
+ignoreMacawAssertions _ p _  = pure p
 
 
 -- | The shared implementation for the @mkGlobalPointerValidityPred@ function in
@@ -191,7 +190,7 @@ mkGlobalPointerValidityPredCommon tbl sym puse mcond ptr = do
   case WI.asNat ptrBase of
     Just 0 -> do
       p <- mkPred ptrOff
-      p' <- trace "annotating a unmapped global err?" (?processMacawAssert sym p (UnmappedGlobalMemoryAccess ptrVal))
+      p' <- ?processMacawAssert sym p (UnmappedGlobalMemoryAccess ptrVal)
       let msg = printf "%s outside of static memory range (known BlockID 0): %s" (show (MS.pointerUseTag puse)) (show (WI.printSymExpr ptrOff))
       let loc = MS.pointerUseLocation puse
       let assertion = CB.LabeledPred p' (CS.SimError loc (CS.GenericSimError msg))

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -50,6 +50,7 @@ import qualified What4.Expr.Builder as WEB
 import qualified What4.Interface as WI
 
 import qualified Data.Macaw.Symbolic as MS
+import Debug.Trace (trace)
 
 -- | A configuration knob controlling how the initial contents of the memory
 -- model are populated
@@ -128,7 +129,7 @@ type MacawProcessAssertion sym
 
 
 ignoreMacawAssertions :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym)
-ignoreMacawAssertions _ p _  = pure p
+ignoreMacawAssertions _ p _  = trace "Processing with ignore macaw assertion"  (pure p)
 
 
 -- | The shared implementation for the @mkGlobalPointerValidityPred@ function in
@@ -190,7 +191,7 @@ mkGlobalPointerValidityPredCommon tbl sym puse mcond ptr = do
   case WI.asNat ptrBase of
     Just 0 -> do
       p <- mkPred ptrOff
-      p' <- ?processMacawAssert sym p (UnmappedGlobalMemoryAccess ptrVal)
+      p' <- trace "annotating a unmapped global err?" (?processMacawAssert sym p (UnmappedGlobalMemoryAccess ptrVal))
       let msg = printf "%s outside of static memory range (known BlockID 0): %s" (show (MS.pointerUseTag puse)) (show (WI.printSymExpr ptrOff))
       let loc = MS.pointerUseLocation puse
       let assertion = CB.LabeledPred p' (CS.SimError loc (CS.GenericSimError msg))

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -19,7 +19,7 @@ module Data.Macaw.Symbolic.Memory.Common
   , mkGlobalPointerValidityPredCommon
   , MacawProcessAssertion
   , MacawError(..)
-  , ignoreMacawAssertions
+  , defaultProcessMacawAssertions
   , mapRegionPointersCommon
   , populateMemChunkBytes
   , memArrEqualityAssumption
@@ -117,18 +117,25 @@ defaultGlobalMemoryHooks =
     }
 
 
+-- | Describes the type of error a Macaw generated predicate represents if the assertion
+-- is violated. See 'MacawProcessAssertion' for information on how to consume this information 
+-- via a callback.
 data MacawError sym where 
   UnmappedGlobalMemoryAccess :: (1 <= w) => CS.RegValue sym (CL.LLVMPointerType w) -> MacawError sym
 
 -- | Given a safety predicate and a description of the error it represents,
 -- return a new predicate (and possibly perform additional side-effects, such as
--- recording information about the predicate).
+-- recording information about the predicate). Typically the callback will want to
+-- annotate the predicate via 'W4.annotateTerm' so that information about the predicate
+-- can be found later.
 type MacawProcessAssertion sym
   = (?processMacawAssert :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym))
 
 
-ignoreMacawAssertions :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym)
-ignoreMacawAssertions _ p _  = pure p
+-- | A default 'MacawProcessAssertion' implementation that simply returns the original predicate
+-- with no effect.
+defaultProcessMacawAssertions :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym)
+defaultProcessMacawAssertions _ p _  = pure p
 
 
 -- | The shared implementation for the @mkGlobalPointerValidityPred@ function in

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -19,7 +19,7 @@ module Data.Macaw.Symbolic.Memory.Common
   , mkGlobalPointerValidityPredCommon
   , MacawProcessAssertion
   , MacawError(..)
-  , defaultProcessMacawAssertions
+  , defaultProcessMacawAssertion
   , mapRegionPointersCommon
   , populateMemChunkBytes
   , memArrEqualityAssumption
@@ -134,8 +134,8 @@ type MacawProcessAssertion sym
 
 -- | A default 'MacawProcessAssertion' implementation that simply returns the original predicate
 -- with no effect.
-defaultProcessMacawAssertions :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym)
-defaultProcessMacawAssertions _ p _  = pure p
+defaultProcessMacawAssertion :: sym -> WI.Pred sym -> MacawError sym -> IO (WI.Pred sym)
+defaultProcessMacawAssertion _ p _  = pure p
 
 
 -- | The shared implementation for the @mkGlobalPointerValidityPred@ function in

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE  ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -118,7 +118,7 @@ defaultGlobalMemoryHooks =
 
 
 data MacawError sym where 
-  UnmappedGlobalMemoryAccess :: CS.RegValue sym (CL.LLVMPointerType w) -> MacawError sym
+  UnmappedGlobalMemoryAccess :: (1 <= w) => CS.RegValue sym (CL.LLVMPointerType w) -> MacawError sym
 
 -- | Given a safety predicate and a description of the error it represents,
 -- return a new predicate (and possibly perform additional side-effects, such as

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
@@ -119,6 +119,7 @@ memModelConfig ::
      , 16 <= w
      , CL.HasLLVMAnn sym
      , ?memOpts :: CL.MemOptions
+     , MSMC.MacawProcessAssertion sym
      )
   => bak
   -> MemPtrTable sym w
@@ -782,6 +783,7 @@ mkGlobalPointerValidityPred ::
      forall sym w
    . ( CB.IsSymInterface sym
      , MC.MemWidth w
+     , MSMC.MacawProcessAssertion sym
      )
   => MemPtrTable sym w
   -> MS.MkGlobalPointerValidityAssertion sym w

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -461,7 +461,7 @@ simulateAndVerify :: forall arch sym bak ids w solver scope st fs
 simulateAndVerify goalSolver logger bak execFeatures archInfo archVals binfo mmPreset extractor dfi =
   MS.withArchConstraints archVals $ do
     halloc <- CFH.newHandleAllocator
-    let ?processMacawAssert = MSMC.ignoreMacawAssertions
+    let ?processMacawAssert = MSMC.defaultProcessMacawAssertion
     let ?recordLLVMAnnotation = \_ _ _ -> return ()
 
     -- Initialize memory

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -105,6 +105,7 @@ import qualified What4.ProgramLoc as WPL
 import qualified What4.Protocol.Online as WPO
 import qualified What4.SatResult as WSR
 import qualified What4.Solver as WS
+import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 
 data TestingException = ELFResolutionError String
   deriving (Show)
@@ -460,6 +461,7 @@ simulateAndVerify :: forall arch sym bak ids w solver scope st fs
 simulateAndVerify goalSolver logger bak execFeatures archInfo archVals binfo mmPreset extractor dfi =
   MS.withArchConstraints archVals $ do
     halloc <- CFH.newHandleAllocator
+    let ?processMacawAssert = MSMC.ignoreMacawAssertions
     let ?recordLLVMAnnotation = \_ _ _ -> return ()
 
     -- Initialize memory
@@ -544,6 +546,7 @@ initialMem ::
   , bak ~ CBO.OnlineBackend solver scope st fs
   , WPO.OnlineSolver solver
   , ?memOpts :: CLM.MemOptions
+  , MSMC.MacawProcessAssertion sym
   ) =>
   BinariesInfo arch ->
   bak ->
@@ -575,6 +578,7 @@ lazyInitialMem ::
   , WPO.OnlineSolver solver
   , ?memOpts :: CLM.MemOptions
   , MS.HasMacawLazySimulatorState p sym w
+  , MSMC.MacawProcessAssertion sym
   ) =>
   BinariesInfo arch ->
   bak ->

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -64,6 +64,7 @@ import qualified Data.Macaw.Memory.ElfLoader.PLTStubs as MELP
 import qualified Data.Macaw.Memory.LoadCommon as MML
 import qualified Data.Macaw.Symbolic as MS
 import qualified Data.Macaw.Symbolic.Memory as MSM
+import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 import qualified Data.Macaw.Symbolic.Memory.Lazy as MSMLazy
 import qualified Data.Macaw.Symbolic.Stack as MSS
 import qualified Data.Macaw.Types as MT
@@ -105,7 +106,6 @@ import qualified What4.ProgramLoc as WPL
 import qualified What4.Protocol.Online as WPO
 import qualified What4.SatResult as WSR
 import qualified What4.Solver as WS
-import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 
 data TestingException = ELFResolutionError String
   deriving (Show)

--- a/x86_symbolic/tests/Main.hs
+++ b/x86_symbolic/tests/Main.hs
@@ -34,6 +34,7 @@ import qualified Test.Tasty.Runners as TTR
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as M
 import qualified Data.Macaw.Symbolic as MS
+import qualified Data.Macaw.Symbolic.Memory as MSM (ignoreMacawAssertions, MacawProcessAssertion)
 import qualified Data.Macaw.Symbolic.Testing as MST
 import qualified Data.Macaw.X86 as MX
 import           Data.Macaw.X86.Symbolic ()
@@ -214,6 +215,7 @@ setupRegsAndMem ::
   , CCE.IsSyntaxExtension ext
   , CB.IsSymBackend sym bak
   , LLVM.HasLLVMAnn sym
+  , MSM.MacawProcessAssertion sym
   , sym ~ W4.ExprBuilder scope st fs
   , bak ~ CBO.OnlineBackend solver scope st fs
   , WPO.OnlineSolver solver
@@ -283,6 +285,7 @@ mkSymExTest expected mmPreset exePath = TT.askOption $ \saveSMT@(SaveSMT _) -> T
               MS.withArchConstraints archVals $ do
                 halloc <- CFH.newHandleAllocator
                 let ?recordLLVMAnnotation = \_ _ _ -> return ()
+                let ?processMacawAssert = MSM.ignoreMacawAssertions
 
                 (regs, iMem) <- setupRegsAndMem bak archVals mmPreset binariesInfo
                 (memVar, execResult) <-

--- a/x86_symbolic/tests/Main.hs
+++ b/x86_symbolic/tests/Main.hs
@@ -34,7 +34,7 @@ import qualified Test.Tasty.Runners as TTR
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as M
 import qualified Data.Macaw.Symbolic as MS
-import qualified Data.Macaw.Symbolic.Memory as MSM (ignoreMacawAssertions, MacawProcessAssertion)
+import qualified Data.Macaw.Symbolic.Memory as MSM (defaultProcessMacawAssertion, MacawProcessAssertion)
 import qualified Data.Macaw.Symbolic.Testing as MST
 import qualified Data.Macaw.X86 as MX
 import           Data.Macaw.X86.Symbolic ()
@@ -285,7 +285,7 @@ mkSymExTest expected mmPreset exePath = TT.askOption $ \saveSMT@(SaveSMT _) -> T
               MS.withArchConstraints archVals $ do
                 halloc <- CFH.newHandleAllocator
                 let ?recordLLVMAnnotation = \_ _ _ -> return ()
-                let ?processMacawAssert = MSM.ignoreMacawAssertions
+                let ?processMacawAssert = MSM.defaultProcessMacawAssertion
 
                 (regs, iMem) <- setupRegsAndMem bak archVals mmPreset binariesInfo
                 (memVar, execResult) <-


### PR DESCRIPTION
Note i removed the fact that this closes the referenced issue as this only adds the error which we would like to refine in Grease currently.

The original issue is #429 
