### PR TITLE
`macaw-symbolic`: Re-export `MacawProcessAssertion` et al. from `Data.Macaw.Symbolic.Memory.Lazy`

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
@@ -35,6 +35,9 @@ module Data.Macaw.Symbolic.Memory.Lazy (
   newGlobalMemoryWith,
   newMergedGlobalMemoryWith,
   MSMC.MemoryModelContents(..),
+  MSMC.MacawProcessAssertion,
+  MSMC.MacawError(..),
+  MSMC.defaultProcessMacawAssertion,
   mkGlobalPointerValidityPred,
   mapRegionPointers
   ) where


### PR DESCRIPTION
Fixes #520.