### PR TITLE
Remove unnecessary `allow-newer:` in `cabal.project`

### DIFF
--- a/cabal.project.dist
+++ b/cabal.project.dist
@@ -1,10 +1,5 @@
 -- See https://github.com/Happstack/boomerang/issues/12
 allow-newer: boomerang:template-haskell
--- See https://github.com/GaloisInc/bv-sized-float/issues/8
-allow-newer: bv-sized-float:containers
--- https://github.com/GaloisInc/grift/issues/13
-allow-newer: grift:containers
-allow-newer: grift:filepath
 -- See https://github.com/travitch/haggle/issues/29
 allow-newer: haggle:primitive
 


### PR DESCRIPTION
I just forgot to commit this change.