### PR TITLE
crucible-macaw-debug: Export `MacawCommand`

### DIFF
--- a/crucible-macaw-debug/src/Data/Macaw/Symbolic/Debug.hs
+++ b/crucible-macaw-debug/src/Data/Macaw/Symbolic/Debug.hs
@@ -6,7 +6,8 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Data.Macaw.Symbolic.Debug
-  ( macawCommandExt
+  ( MacawCommand
+  , macawCommandExt
   , macawExtImpl
   ) where
 


### PR DESCRIPTION
...as it can be mentioned in type signatures.