### PR TITLE
Add updates for all regs at block entry

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
@@ -1771,7 +1771,7 @@ addRegUpdateForBlock archFns startAddr = do
   void $ evalMacawStmt $ MacawArchStateUpdate (M.segoffAddr startAddr) mp
  where
   updatesFromRegStruct ::
-    (OrdF (M.ArchReg arch)) =>
+    OrdF (M.ArchReg arch) =>
     Assignment (M.ArchReg arch) ctx ->
     CrucGen arch ids s (MapF.MapF (M.ArchReg arch) (MacawCrucibleValue (CR.Atom s)))
   updatesFromRegStruct = foldlMFC' (\mp reg -> do


### PR DESCRIPTION
MacawArchUpdateState does not currently make it possible to track the initial state of registers in blocks coming from block args. This limitation makes it hard to track the state of registers in the crucibleCFG purely by these statements. This PR causes an initial update to be emitted for all registers and is used downstream for https://github.com/GaloisInc/grease/pull/447

I could see an argument against mangling the CFG like this but the regs are already in the incoming reg struct and the CFG is already kinda hard to read as is so im not sure it's worth  creating difficulty downstream for this. (The alternative i suppose would be to capture jumps to blocks in a feature or something and record the register state then)