### PR TITLE
Install system dependencies before installing GHC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y software-properties-common apt-transport-https ca-certificates wget
-        sudo apt install -y curl zlibc zlib1g zlib1g-dev git zip \
+        sudo apt install -y curl zlib1g zlib1g-dev git zip \
           libgmp3-dev build-essential libtinfo-dev autoconf automake gperf cmake locales \
-          python3-distutils python-setuptools antlr3 libantlr3c-dev libtool libtool-bin libboost-all-dev python3-pip libfftw3-dev \
+          antlr3 libantlr3c-dev libtool libtool-bin libboost-all-dev python3-pip libfftw3-dev \
           language-pack-en-base language-pack-en
         sudo locale-gen en_US.UTF-8
         sudo update-locale LANG=$LANG LANGUAGE=$LANGUAGE


### PR DESCRIPTION
Because we are installing GHC via `ghcup` on a self-hosted runner, it is our responsibility to ensure that we have installed of of GHC's software dependencies before we attempt to install GHC itself. (On GitHub-hosted runners, these dependencies are already installed by default.)

Fixes #548.