### PR TITLE
Add an additional transfer function for computing bounds of indices stored on the stack

### DIFF
--- a/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
+++ b/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
@@ -242,7 +242,6 @@ execStatement bnds stmt =
   case stmt of
     AssignStmt (Assignment aid arhs) -> do
       let bnds1 = case arhs of
-
                     ReadMem addrVal readRepr
                       | False <- intraMemCleared bnds
                       , Just addr <- valueAsMemAddr addrVal
@@ -258,7 +257,7 @@ execStatement bnds stmt =
                       -- will have the same bounds from 3.
                       | False <- intraMemCleared bnds
                       , StackOffsetExpr off <- intraStackValueExpr (intraStackConstraints bnds) addrVal
-                      , Just bnd <- locLookup (StackOffLoc off readRepr)  (initRngPredMap (intraInitBounds bnds)) ->
+                      , Just bnd <- locLookup (StackOffLoc off readRepr) (initRngPredMap (intraInitBounds bnds)) ->
                             bnds { intraReadPredMap = MapF.insert aid bnd (intraReadPredMap bnds) }
                     -- Clear all knowledge about the stack on architecture-specific
                     -- functions that accept stack pointer as they may have side effects.


### PR DESCRIPTION
Previously a jump table index stored on the stack would not maintain bounds. This PR propagates the bounds of a stack location assuming there has not been an intervening write