### PR TITLE
DWARF: Add parser for DW_AT_count in DW_TAG_subrange_type

### DIFF
--- a/base/src/Data/Macaw/Dwarf.hs
+++ b/base/src/Data/Macaw/Dwarf.hs
@@ -559,7 +559,7 @@ parseEnumerator d = runDIEParser "parseEnumerator" d $ do
 ------------------------------------------------------------------------
 
 {- | Declares the upper bounds of a 'Subrange' either via a count (DW_AT_count)
-or via an upper bound (DW_AT_upperbound)
+or via an upper bound (DW_AT_upper_bound)
 -}
 data SubrangeBounds
   = SubrangeUpperBound [DW_OP]


### PR DESCRIPTION
Allows parsing subrange types that declare an upper bound via the count attribute. Closes #507 