### PR TITLE
Lazy memory model: store `ByteString`s and `Vec`s, not `Seq`s

### DIFF
--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -24,7 +24,6 @@ library
     panic,
     parameterized-utils,
     prettyprinter >= 1.7.0,
-    split,
     text,
     vector >= 0.13.2,
     bytestring,
@@ -87,6 +86,7 @@ test-suite macaw-symbolic-tests
     hedgehog >= 1.0.2,
     tasty >= 1.2.3 && < 1.6,
     tasty-hedgehog >= 1.2 && < 1.5,
-    tasty-hunit
+    tasty-hunit,
+    vector
 
 

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -134,6 +134,8 @@ module Data.Macaw.Symbolic.Memory (
 import           GHC.TypeLits
 
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
+import qualified Data.BitVector.Sized as BV
+import qualified Data.ByteString as BS
 import           Data.Functor.Identity ( Identity(Identity) )
 import qualified Data.IntervalMap.Strict as IM
 
@@ -362,8 +364,40 @@ populateMemory proxy cache hooks bak mmc mems symArray0 =
   MSMC.pleatM (symArray0, IM.empty) mems $ \allocs0 mem ->
     MSMC.pleatM allocs0 (MC.memSegments mem) $ \allocs1 seg -> do
       MSMC.pleatM allocs1 (MC.relativeSegmentContents [seg]) $ \(symArray, allocs2) (addr, memChunk) -> do
-        concreteBytes <- MSMC.populateMemChunkBytes cache bak hooks mem seg addr memChunk
+        concreteBytes <- populateMemChunkBytes cache bak hooks mem seg addr memChunk
         populateSegmentChunk proxy bak mmc mem symArray seg addr concreteBytes allocs2
+
+-- | Convert each byte in a 'MC.MemChunk' to the corresponding bytes. These
+-- can possibly be symbolic bytes depending on the behavior of the
+-- 'GlobalMemoryHooks'.
+populateMemChunkBytes ::
+     ( MonadIO m
+     , CB.IsSymBackend sym bak
+     , MC.MemWidth w
+     )
+  => MBC.ByteCache sym
+  -> bak
+  -> MSMC.GlobalMemoryHooks w
+  -> MC.Memory w
+  -> MC.MemSegment w
+  -> MC.MemAddr w
+  -> MC.MemChunk w
+  -> m [WI.SymBV sym 8]
+populateMemChunkBytes cache bak hooks mem seg addr memChunk =
+  liftIO $
+  case memChunk of
+    MC.RelocationRegion reloc ->
+      MSMC.populateRelocation hooks bak mem seg addr reloc
+    MC.BSSRegion sz ->
+      replicate (fromIntegral sz) <$> WI.bvLit sym w8 (BV.zero w8)
+    MC.ByteRegion bytes -> do
+      -- Use the shared byte cache to avoid allocating fresh SemiRingLiteral
+      -- terms for each byte. For large binaries this saves gigabytes of heap.
+      -- Force evaluation to prevent thunk buildup.
+      traverse (MBC.indexByteCacheM cache) (BS.unpack bytes)
+  where
+    sym = CB.backendGetSym bak
+    w8 = WI.knownNat @8
 
 -- | If we want to treat the contents of this chunk of memory (the bytes at the
 -- 'MemAddr') as concrete, assert that the bytes from the symbolic array backing

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -21,7 +21,6 @@ module Data.Macaw.Symbolic.Memory.Common
   , MacawError(..)
   , defaultProcessMacawAssertion
   , mapRegionPointersCommon
-  , populateMemChunkBytes
   , memArrEqualityAssumption
   , pleatM
   , ipleatM
@@ -32,14 +31,12 @@ import           GHC.TypeLits
 import qualified Control.Lens as L
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import qualified Data.BitVector.Sized as BV
-import qualified Data.ByteString as BS
 import qualified Data.Foldable as F
 import qualified Data.Foldable.WithIndex as FWI
 import qualified Data.IntervalMap.Strict as IM
 
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Macaw.CFG as MC
-import qualified Data.Macaw.Symbolic.Memory.ByteCache as MBC
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.LLVM.DataLayout as CLD
 import qualified Lang.Crucible.LLVM.MemModel as CL
@@ -262,38 +259,6 @@ mapRegionPointersCommon ptr = MS.GlobalMap $ \bak mem regionNum offsetVal ->
       -- The pointer mapped to global memory (if the region number is zero)
       globalPtr <- CL.doPtrAddOffset bak mem ptr offsetVal
       CL.muxLLVMPtr sym isZeroRegion globalPtr (CL.LLVMPointer regionNum offsetVal)
-
--- | Convert each byte in a 'MC.MemChunk' to the corresponding bytes. These
--- can possibly be symbolic bytes depending on the behavior of the
--- 'GlobalMemoryHooks'.
-populateMemChunkBytes ::
-     ( MonadIO m
-     , CB.IsSymBackend sym bak
-     , MC.MemWidth w
-     )
-  => MBC.ByteCache sym
-  -> bak
-  -> GlobalMemoryHooks w
-  -> MC.Memory w
-  -> MC.MemSegment w
-  -> MC.MemAddr w
-  -> MC.MemChunk w
-  -> m [WI.SymBV sym 8]
-populateMemChunkBytes cache bak hooks mem seg addr memChunk =
-  liftIO $
-  case memChunk of
-    MC.RelocationRegion reloc ->
-      populateRelocation hooks bak mem seg addr reloc
-    MC.BSSRegion sz ->
-      replicate (fromIntegral sz) <$> WI.bvLit sym w8 (BV.zero w8)
-    MC.ByteRegion bytes -> do
-      -- Use the shared byte cache to avoid allocating fresh SemiRingLiteral
-      -- terms for each byte. For large binaries this saves gigabytes of heap.
-      -- Force evaluation to prevent thunk buildup.
-      traverse (MBC.indexByteCacheM cache) (BS.unpack bytes)
-  where
-    sym = CB.backendGetSym bak
-    w8 = WI.knownNat @8
 
 -- | Generate an 'AB.Assumption' that particular elements of the array backing
 -- global memory are equal to the appropriate bytes. This function does not add

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy/Internal.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy/Internal.hs
@@ -3,10 +3,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
+
 -- | Internal module for "Data.Macaw.Symbolic.Memory.Lazy".
 --
 -- This module exposes all internals for testing purposes.
@@ -25,9 +27,9 @@ module Data.Macaw.Symbolic.Memory.Lazy.Internal (
 
   -- * Internal (exported for testing)
   SymbolicMemChunk(..),
-  combineSymbolicMemChunks,
-  combineIfContiguous,
-  combineChunksIfContiguous,
+  MemChunkBytes(..),
+  memChunkBytesLen,
+  checkContiguous,
   extendUpperBound,
   splitInterval,
   chunksOfInterval,
@@ -53,15 +55,15 @@ import           GHC.TypeLits
 import qualified Control.Exception as X
 import qualified Control.Lens as L
 import           Control.Lens ((^.))
+import           Control.Monad ( guard )
 import           Control.Monad.IO.Class ( MonadIO, liftIO )
 import qualified Data.BitVector.Sized as BV
-import qualified Data.Foldable as F
+import qualified Data.ByteString as BS
 import           Data.Functor.Identity ( Identity(Identity) )
 import qualified Data.IntervalMap.Interval as IMI
 import qualified Data.IntervalMap.Strict as IM
 import qualified Data.IntervalSet as IS
-import qualified Data.List.Split as Split
-import qualified Data.Sequence as Seq
+import qualified Data.Vector as Vec
 
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Vector as PV
@@ -141,7 +143,7 @@ memModelConfig bak mpt =
     , MS.lookupSyscallHandle = MS.unsupportedSyscalls origin
     , MS.mkGlobalPointerValidityAssertion = mkGlobalPointerValidityPred mpt
     , MS.resolvePointer = MSC.resolveLLVMPtr bak
-    , MS.concreteImmutableGlobalRead = concreteImmutableGlobalRead sym (memPtrTable mpt) (CLP.llvmPointerBlock (memPtr mpt))
+    , MS.concreteImmutableGlobalRead = concreteImmutableGlobalRead sym (memPtrTable mpt) (byteCache mpt) (CLP.llvmPointerBlock (memPtr mpt))
     , MS.lazilyPopulateGlobalMem = lazilyPopulateGlobalMemArr bak mpt
     }
   where
@@ -172,40 +174,49 @@ data MemPtrTable sym w = MemPtrTable
   -- ^ See "Data.Macaw.Symbolic.Memory.ByteCache"
   }
 
+-- | The backing bytes for a 'SymbolicMemChunk'. For the common case of
+-- concrete byte data from the binary, we store the raw 'BS.ByteString' to avoid
+-- materializing What4 expressions upfront. Expressions are only created on
+-- demand when a chunk is actually accessed, using the shared 'MBC.ByteCache'.
+data MemChunkBytes sym
+  = ConcreteBytes !BS.ByteString
+    -- ^ Raw bytes from the binary (e.g., from 'MC.ByteRegion'). Symbolic
+    --   expressions are created on demand during lazy population via the
+    --   shared 'MBC.ByteCache'.
+  | SymbolicBytes !(Vec.Vector (WI.SymBV sym 8))
+    -- ^ Truly symbolic bytes (e.g., from relocations) that cannot be
+    --   represented as a raw 'BS.ByteString'.
+
+memChunkBytesLen :: MemChunkBytes sym -> Int
+memChunkBytesLen = \case
+  ConcreteBytes bs -> BS.length bs
+  SymbolicBytes s  -> Vec.length s
+
 -- | A discrete chunk of a memory segment within global memory. Memory is
 -- lazily initialized one 'SymbolicMemChunk' at a time. See
 -- @Note [Lazy memory model]@.
 data SymbolicMemChunk sym = SymbolicMemChunk
-  { smcBytes :: Seq.Seq (WI.SymBV sym 8)
+  { smcBytes :: MemChunkBytes sym
     -- ^ A contiguous region of symbolic bytes backing global memory.
-    --   The size of this region is no larger than 'chunkSize'. We represent
-    --   this as a 'Seq.Seq' since we frequently need to append it to other
-    --   regions (see 'combineSymbolicMemChunks').
+    --   The size of this region is no larger than 'chunkSize'.
   , smcMutability :: CL.Mutability
     -- ^ Whether the region of memory is mutable or immutable.
   }
 
--- | If two 'SymbolicMemChunk's have the same 'LCLM.Mutability', then return
--- @'Just' chunk@, where @chunk@ contains the two arguments' bytes concatenated
--- together. Otherwise, return 'Nothing'.
-combineSymbolicMemChunks ::
-  SymbolicMemChunk sym ->
-  SymbolicMemChunk sym ->
-  Maybe (SymbolicMemChunk sym)
-combineSymbolicMemChunks
-  (SymbolicMemChunk{smcBytes = bytes1, smcMutability = mutability1})
-  (SymbolicMemChunk{smcBytes = bytes2, smcMutability = mutability2})
-  | mutability1 == mutability2
-  = Just $ SymbolicMemChunk
-             { smcBytes = bytes1 <> bytes2
-             , smcMutability = mutability1
-             }
-  | otherwise
-  = Nothing
+-- | Split a 'BS.ByteString' into chunks of at most @n@ bytes.
+bsChunksOf :: Int -> BS.ByteString -> [BS.ByteString]
+bsChunksOf n bs
+  | BS.null bs = []
+  | otherwise  = let (h, t) = BS.splitAt n bs in h : bsChunksOf n t
 
--- | @'combineIfContiguous' i1 i2@ returns 'Just' an interval with the lower
--- bound of @i1@ and the upper bound of @i2@ when one of the following criteria
--- are met:
+-- | Split a 'Vec.Vector' into chunks of at most @n@ elements.
+vecChunksOf :: Int -> Vec.Vector a -> [Vec.Vector a]
+vecChunksOf n v
+  | Vec.null v = []
+  | otherwise  = let (h, t) = Vec.splitAt n v in h : vecChunksOf n t
+
+-- | @'checkContiguous' i1 i2@ returns 'True' when one of the following
+-- criteria are met:
 --
 -- * If @i1@ has an open upper bound, then @i2@ has a closed lower bound of the
 --   same integral value.
@@ -220,61 +231,61 @@ combineSymbolicMemChunks
 -- * It is not the case that both @i1@'s upper bound and @i2@'s lower bound are
 --   open.
 --
--- Otherwise, this returns 'Nothing'.
+-- Otherwise, this returns 'False'.
 --
--- Less formally, this captures the notion of combining two non-overlapping
--- 'IMI.Interval's that when would form a single, contiguous range when
+-- Less formally, this captures the notion of checking whether two
+-- non-overlapping 'IMI.Interval's would form a single, contiguous range when
 -- overlaid. (Contrast this with 'IMI.combine', which only returns 'Just' if
 -- the two 'IMI.Interval's are overlapping.)
-combineIfContiguous :: (Eq a, Integral a) => IMI.Interval a -> IMI.Interval a -> Maybe (IMI.Interval a)
-combineIfContiguous i1 i2 =
+checkContiguous :: (Eq a, Integral a) => IMI.Interval a -> IMI.Interval a -> Bool
+checkContiguous i1 i2 =
   case (i1, i2) of
-    (IMI.IntervalOC lo1 hi1, IMI.IntervalOC lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.IntervalOC lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.IntervalOC lo1 hi1, IMI.OpenInterval lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.OpenInterval lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.OpenInterval lo1 hi1, IMI.IntervalCO lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.OpenInterval lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.OpenInterval lo1 hi1, IMI.ClosedInterval lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.IntervalOC lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.IntervalCO lo1 hi1, IMI.IntervalCO lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.IntervalCO lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.IntervalCO lo1 hi1, IMI.ClosedInterval lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.ClosedInterval lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.ClosedInterval lo1 hi1, IMI.IntervalOC lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.ClosedInterval lo1 hi2
-      | otherwise  -> Nothing
-    (IMI.ClosedInterval lo1 hi1, IMI.OpenInterval lo2 hi2)
-      | hi1 == lo2 -> Just $ IMI.IntervalCO lo1 hi2
-      | otherwise  -> Nothing
+    (IMI.IntervalOC _ hi1, IMI.IntervalOC lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.IntervalOC _ hi1, IMI.OpenInterval lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.OpenInterval _ hi1, IMI.IntervalCO lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.OpenInterval _ hi1, IMI.ClosedInterval lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.IntervalCO _ hi1, IMI.IntervalCO lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.IntervalCO _ hi1, IMI.ClosedInterval lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.ClosedInterval _ hi1, IMI.IntervalOC lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
+    (IMI.ClosedInterval _ hi1, IMI.OpenInterval lo2 _)
+      | hi1 == lo2 -> True
+      | otherwise  -> False
 
-    (IMI.IntervalOC lo1 hi1, IMI.IntervalCO lo2 hi2)
-      | hi1 + 1 == lo2 -> Just $ IMI.OpenInterval lo1 hi2
-      | otherwise      -> Nothing
-    (IMI.IntervalOC lo1 hi1, IMI.ClosedInterval lo2 hi2)
-      | hi1 + 1 == lo2 -> Just $ IMI.IntervalOC lo1 hi2
-      | otherwise      -> Nothing
-    (IMI.ClosedInterval lo1 hi1, IMI.IntervalCO lo2 hi2)
-      | hi1 + 1 == lo2 -> Just $ IMI.IntervalCO lo1 hi2
-      | otherwise      -> Nothing
-    (IMI.ClosedInterval lo1 hi1, IMI.ClosedInterval lo2 hi2)
-      | hi1 + 1 == lo2 -> Just $ IMI.ClosedInterval lo1 hi2
-      | otherwise      -> Nothing
+    (IMI.IntervalOC _ hi1, IMI.IntervalCO lo2 _)
+      | hi1 + 1 == lo2 -> True
+      | otherwise      -> False
+    (IMI.IntervalOC _ hi1, IMI.ClosedInterval lo2 _)
+      | hi1 + 1 == lo2 -> True
+      | otherwise      -> False
+    (IMI.ClosedInterval _ hi1, IMI.IntervalCO lo2 _)
+      | hi1 + 1 == lo2 -> True
+      | otherwise      -> False
+    (IMI.ClosedInterval _ hi1, IMI.ClosedInterval lo2 _)
+      | hi1 + 1 == lo2 -> True
+      | otherwise      -> False
 
     (IMI.IntervalCO{}, IMI.IntervalOC{})
-      -> Nothing
+      -> False
     (IMI.IntervalCO{}, IMI.OpenInterval{})
-      -> Nothing
+      -> False
     (IMI.OpenInterval{}, IMI.IntervalOC{})
-      -> Nothing
+      -> False
     (IMI.OpenInterval{}, IMI.OpenInterval{})
-      -> Nothing
+      -> False
 
 -- | Extend the upper bound of an 'IMI.Interval' by the given amount.
 extendUpperBound :: Num a => IMI.Interval a -> a -> IMI.Interval a
@@ -285,29 +296,86 @@ extendUpperBound i extendBy =
     IMI.OpenInterval   lo hi -> IMI.OpenInterval   lo (hi + extendBy)
     IMI.ClosedInterval lo hi -> IMI.ClosedInterval lo (hi + extendBy)
 
--- | Given a list of memory regions and the symbolic bytes backing them,
--- attempt to combine them into a single region. Return 'Just' if the memory
--- can be combined into a single, contiguous region with no overlap and the
--- backing memory has the same 'LCLM.Mutability. Return 'Nothing' otherwise.
-combineChunksIfContiguous ::
+-- | Given a read address, a number of bytes, and a list of memory regions with
+-- backing bytes, extract the requested bytes by slicing the chunks.
+--
+-- @
+--      chunk0         chunk1     chunk2       chunk3
+--  |--------------|------------|--------|---------------|
+--  |skip|         |                     |tail|
+--       |<------------ numBytes ------------>|
+--      addr                             addr + numBytes
+-- @
+--
+-- Returns 'Just' if the chunks are contiguous, all immutable, and cover the
+-- full read window. Returns 'Nothing' otherwise.
+sliceContiguousChunks ::
   forall a sym.
   (Eq a, Integral a) =>
+  MBC.ByteCache sym ->
+  a ->
+  -- ^ The address being read from
+  Int ->
+  -- ^ Number of bytes to read
   [(IMI.Interval a, SymbolicMemChunk sym)] ->
-  Maybe (IMI.Interval a, SymbolicMemChunk sym)
-combineChunksIfContiguous ichunks =
-  case L.uncons ichunks of
-    Nothing -> Nothing
-    Just (ichunkHead, ichunkTail) -> F.foldl' f (Just ichunkHead) ichunkTail
+  Maybe [WI.SymBV sym 8]
+sliceContiguousChunks cache addr numBytes =
+  \case
+    _ | numBytes <= 0 -> Just []
+    [] -> Nothing
+    ((firstI, firstC) : rest) -> do
+      guard (addr >= IMI.lowerBound firstI)
+      guard (smcMutability firstC == CL.Immutable)
+      let skip = convert (addr - IMI.lowerBound firstI)
+          firstLen = intervalLen firstI
+          avail = firstLen - skip
+          firstTake = min numBytes avail
+          trimmedFirst = sliceBytes skip firstTake (smcBytes firstC)
+      X.assert (firstTake > 0) $ guard (firstTake > 0)
+      let remaining = numBytes - firstTake
+      go firstI remaining trimmedFirst rest
   where
-    f ::
-      Maybe (IMI.Interval a, SymbolicMemChunk sym) ->
-      (IMI.Interval a, SymbolicMemChunk sym) ->
-      Maybe (IMI.Interval a, SymbolicMemChunk sym)
-    f acc (i2, chunk2) = do
-      (i1, chunk1) <- acc
-      combinedI <- combineIfContiguous i1 i2
-      combinedChunk <- combineSymbolicMemChunks chunk1 chunk2
-      pure (combinedI, combinedChunk)
+    convert = fromIntegral @a @Int
+
+    -- We expect IntervalCOs
+    intervalLen :: IMI.Interval a -> Int
+    intervalLen = \case
+      IMI.IntervalCO lo hi -> convert (hi - lo)
+      _ -> X.assert False 0
+
+    sliceBytes :: Int -> Int -> MemChunkBytes sym -> [WI.SymBV sym 8]
+    sliceBytes drop_ take_ = \case
+      ConcreteBytes bs ->
+        [ MBC.indexByteCache cache (BS.index bs i)
+        | i <- [drop_ .. drop_ + take_ - 1]
+        ]
+      SymbolicBytes s ->
+        Vec.toList (Vec.slice take_ drop_ s)
+
+    takeBytes :: Int -> MemChunkBytes sym -> [WI.SymBV sym 8]
+    takeBytes = sliceBytes 0
+
+    allBytes :: MemChunkBytes sym -> [WI.SymBV sym 8]
+    allBytes mcb = sliceBytes 0 (memChunkBytesLen mcb) mcb
+
+    go ::
+      IMI.Interval a -> Int -> [WI.SymBV sym 8] ->
+      [(IMI.Interval a, SymbolicMemChunk sym)] ->
+      Maybe [WI.SymBV sym 8]
+    go prev remaining acc = \case
+      _ | remaining <= 0 -> X.assert (length acc == numBytes) $ Just acc
+      [] -> Nothing
+      ((ival, chunk) : rest) -> do
+        guard (checkContiguous prev ival)
+        guard (smcMutability chunk == CL.Immutable)
+        let chunkLen = intervalLen ival
+        let remaining' = remaining - chunkLen
+        -- (++) is O(n^2), but these lists are a maximum of 8 elements (bytes)
+        if remaining' < 0
+          then let result = acc ++ takeBytes remaining (smcBytes chunk)
+               in X.assert (length result == numBytes) $ Just result
+          else go ival remaining'
+                  (acc ++ allBytes (smcBytes chunk)) rest
 
 -- | The maximum size of a 'SymbolicMemChunk', which determines the granularity
 -- at which the regions of memory in a 'memPtrTable' are chunked up.
@@ -555,9 +623,10 @@ newMergedGlobalMemoryWith hooks _proxy bak endian mmc mems = do
                          "Global memory for macaw-symbolic"
                          memImpl1 sizeBV CLD.noAlignment
 
-  cache <- liftIO $ MBC.mkByteCache sym
+  tbl <- mergedMemorySymbolicMemChunks bak hooks mems
 
-  tbl <- mergedMemorySymbolicMemChunks cache bak hooks mems
+  -- Create the shared byte cache once (all 256 possible byte values)
+  cache <- liftIO $ MBC.mkByteCache sym
 
   memImpl3 <- liftIO $ CL.doArrayStore bak memImpl2 ptr CLD.noAlignment symArray sizeBV
   let ptrTable = MemPtrTable
@@ -581,12 +650,11 @@ mergedMemorySymbolicMemChunks ::
   , Traversable t
   , MonadIO m
   ) =>
-  MBC.ByteCache sym ->
   bak ->
   MSMC.GlobalMemoryHooks w ->
   t (MC.Memory w) ->
   m (IM.IntervalMap (MC.MemWord w) (SymbolicMemChunk sym))
-mergedMemorySymbolicMemChunks cache bak hooks mems =
+mergedMemorySymbolicMemChunks bak hooks mems =
   fmap (IM.fromList . concat) $ traverse memorySymbolicMemChunks mems
   where
     memorySymbolicMemChunks ::
@@ -602,7 +670,6 @@ mergedMemorySymbolicMemChunks cache bak hooks mems =
     segmentSymbolicMemChunks mem seg = concat <$>
       traverse
         (\(addr, chunk) -> do
-          allBytes <- MSMC.populateMemChunkBytes cache bak hooks mem seg addr chunk
           let mut | MMP.isReadonly (MC.segmentFlags seg) = CL.Immutable
                   | otherwise                            = CL.Mutable
           let absAddr =
@@ -611,14 +678,9 @@ mergedMemorySymbolicMemChunks cache bak hooks mems =
                   Nothing -> error $
                     "segmentSymbolicMemChunks: Failed to resolve function address: " ++
                     show addr
-          let size = length allBytes
+          (smcChunks, size) <- memChunkToSymbolic mut mem seg addr chunk
           let interval = IM.IntervalCO absAddr (absAddr + fromIntegral size)
           let intervalChunks = chunksOfInterval (fromIntegral chunkSize) interval
-          let smcChunks = map (\bytes -> SymbolicMemChunk
-                                           { smcBytes = Seq.fromList bytes
-                                           , smcMutability = mut
-                                           })
-                              (Split.chunksOf chunkSize allBytes)
           -- The length of these two lists should be the same, as
           -- @chunksOfInterval size@ should return a list of the same
           -- size as @Split.chunksOf size@.
@@ -626,19 +688,53 @@ mergedMemorySymbolicMemChunks cache bak hooks mems =
                $ zip intervalChunks smcChunks)
         (MC.relativeSegmentContents [seg])
 
+    memChunkToSymbolic ::
+      CL.Mutability ->
+      MC.Memory w ->
+      MC.MemSegment w ->
+      MC.MemAddr w ->
+      MC.MemChunk w ->
+      m ([SymbolicMemChunk sym], Int)
+    memChunkToSymbolic mut mem seg addr = \case
+      MC.ByteRegion bs ->
+        pure (concreteChunks bs, BS.length bs)
+      MC.BSSRegion sz ->
+        let szInt = fromIntegral @(MC.MemWord w) @Int sz
+            bs = BS.replicate szInt 0
+        in pure (concreteChunks bs, szInt)
+      MC.RelocationRegion reloc -> do
+        symBytes <- liftIO $
+          MSMC.populateRelocation hooks bak mem seg addr reloc
+        let len = length symBytes
+        pure (symbolicChunks (Vec.fromList symBytes), len)
+      where
+        concreteChunks :: BS.ByteString -> [SymbolicMemChunk sym]
+        concreteChunks bs =
+          map (\c -> SymbolicMemChunk (ConcreteBytes c) mut)
+              (bsChunksOf chunkSize bs)
+
+        symbolicChunks :: Vec.Vector (WI.SymBV sym 8) -> [SymbolicMemChunk sym]
+        symbolicChunks v =
+          map (\c -> SymbolicMemChunk (SymbolicBytes c) mut)
+              (vecChunksOf chunkSize v)
+
+
 -- Return @Just val@ if we can be absolutely sure that this is a concrete
 -- read from a contiguous region of immutable, global memory, where the type of
 -- @val@ is determined by the @'MC.MemRepr' ty@ argument.
 -- Return @Nothing@ otherwise. See @Note [Lazy memory model]@.
 concreteImmutableGlobalRead ::
+  forall sym w.
   (CB.IsSymInterface sym, MC.MemWidth w) =>
   sym ->
   IM.IntervalMap (MC.MemWord w) (SymbolicMemChunk sym) ->
   -- ^ The interval map of global memory chunks
+  MBC.ByteCache sym ->
+  -- ^ Byte cache for creating symbolic expressions on demand
   WI.SymNat sym ->
   -- ^ The global memory block number
   MS.ConcreteImmutableGlobalRead sym w
-concreteImmutableGlobalRead sym imap memPtrBlk memRep ptr
+concreteImmutableGlobalRead sym imap cache memPtrBlk memRep ptr
   | -- First, check that the pointer being read from is concrete.
     Just ptrBlkNat <- WI.asNat ptrBlk
   , Just addrBV    <- WI.asBV ptrOff
@@ -648,32 +744,14 @@ concreteImmutableGlobalRead sym imap memPtrBlk memRep ptr
   , Just memPtrBlkNat <- WI.asNat memPtrBlk
   , ptrBlkNat == memPtrBlkNat
 
-    -- Next, look up the chunks that intersect the read range.
-  , let addr = fromInteger $ BV.asUnsigned addrBV
-  , let endAddr = addr + fromIntegral numBytes
-  , let matching = imap `IM.intersecting` IMI.IntervalCO addr endAddr
-
-    -- Next, check that the read starts within the first matching chunk.
-    -- The intersecting query can return chunks that start after addr,
-    -- and without this check addr - lowerBound underflows.
-  , Just (firstInterval, _) <- IM.lookupMin matching
-  , addr >= IMI.lowerBound firstInterval
-
-    -- Next, check that all matching chunks are contiguous.
-  , Just (addrBaseInterval, smc) <-
-      combineChunksIfContiguous (IM.toAscList matching)
-
-    -- Next, check that the memory is immutable.
-  , smcMutability smc == CL.Immutable
-
-    -- Finally, check that the region of memory is large enough to cover
-    -- the number of bytes we are attempting to read.
-  , let addrOffset = fromIntegral $ addr - IMI.lowerBound addrBaseInterval
-  , numBytes <= (length (smcBytes smc) - addrOffset)
-  = do let bytes = Seq.take numBytes $
-                   Seq.drop addrOffset $
-                   smcBytes smc
-       readVal <- readBytesAsRegValue sym memRep $ F.toList bytes
+    -- Next, look up the chunks that intersect the read range and try to
+    -- extract contiguous, immutable bytes covering the full read.
+  , let addr = fromInteger @(MC.MemWord w) $ BV.asUnsigned addrBV
+  , let endAddr = addr + fromIntegral @Int @(MC.MemWord w) numBytes
+  , let chunks = IM.toAscList $
+          imap `IM.intersecting` IMI.IntervalCO addr endAddr
+  , Just bytes <- sliceContiguousChunks cache addr numBytes chunks
+  = do readVal <- readBytesAsRegValue sym memRep bytes
        pure $ Just readVal
 
   | otherwise
@@ -710,7 +788,7 @@ lazilyPopulateGlobalMemArr bak mpt memRep ptr state
                 not (smcMutability smc == CL.Mutable &&
                      memModelContents mpt == MSMC.SymbolicMutable)
            then do bytesAssmp <-
-                     MSMC.memArrEqualityAssumption sym (memPtrArray mpt)
+                     populateChunkAssumption (byteCache mpt) sym (memPtrArray mpt)
                        (IMI.lowerBound addr) (smcBytes smc)
                    -- See @Note [Top-level assumptions]@.
                    gc <- CB.saveAssumptionState bak
@@ -767,6 +845,29 @@ its assumptions (`saveAssumptionState`), add a "top-level" assumption
 For online backends, this will result in resetting the solver process and
 re-asserting all of the in-scope assumptions.
 -}
+
+-- | Build an assumption that constrains the SMT array backing global memory
+-- to have the given bytes at the given address.
+--
+-- For concrete bytes, we map through the shared 'MBC.ByteCache' to obtain
+-- symbolic byte literals without allocating fresh What4 expressions.
+populateChunkAssumption ::
+  forall sym t st fs w.
+  ( sym ~ WEB.ExprBuilder t st fs
+  , MC.MemWidth w
+  ) =>
+  MBC.ByteCache sym ->
+  sym ->
+  WI.SymArray sym (Ctx.SingleCtx (WI.BaseBVType w)) (WI.BaseBVType 8) ->
+  MC.MemWord w ->
+  MemChunkBytes sym ->
+  IO (CB.Assumption sym)
+populateChunkAssumption cache sym symArray absAddr = \case
+  ConcreteBytes bs ->
+    MSMC.memArrEqualityAssumption sym symArray absAddr
+      (map (MBC.indexByteCache cache) (BS.unpack bs))
+  SymbolicBytes s ->
+    MSMC.memArrEqualityAssumption sym symArray absAddr s
 
 -- | Return an 'IMI.Interval' representing the possible range of addresses that
 -- a 'WI.SymBV' can lie between. If this is a concrete bitvector, the interval

--- a/symbolic/test/Lazy.hs
+++ b/symbolic/test/Lazy.hs
@@ -16,7 +16,6 @@ import qualified Data.ByteString as BS
 import qualified Data.IntervalMap.Strict as IM
 import qualified Data.IntervalMap.Interval as IMI
 import           Data.Maybe (isNothing)
-import qualified Data.Sequence as Seq
 import           Data.Word (Word8, Word32, Word64)
 import           Numeric.Natural (Natural)
 
@@ -133,14 +132,13 @@ bvMemReprForSize = \case
   32 -> Just (SomeBVMemRepr bv32)
   _  -> Nothing
 
--- | Build a SymbolicMemChunk from concrete bytes using a ByteCache.
+-- | Build a SymbolicMemChunk from concrete bytes.
 mkChunk ::
-  ByteCache sym ->
   [Word8] ->
   CL.Mutability ->
   SymbolicMemChunk sym
-mkChunk cache bytes mut = SymbolicMemChunk
-  { smcBytes = Seq.fromList (map (indexByteCache cache) bytes)
+mkChunk bytes mut = SymbolicMemChunk
+  { smcBytes = ConcreteBytes (BS.pack bytes)
   , smcMutability = mut
   }
 
@@ -154,10 +152,10 @@ mkIntervalMap ::
 mkIntervalMap entries = IM.fromList
   [ ( IMI.IntervalCO
         (checkedToMemWord @w lo)
-        (checkedToMemWord @w lo
-          + checkedToMemWord @w (fromIntegral @Int @Word64 (Seq.length (smcBytes c))))
+        (checkedToMemWord @w lo + checkedToMemWord @w len)
     , c )
   | (lo, c) <- entries
+  , let len = fromIntegral @Int @Word64 (memChunkBytesLen (smcBytes c))
   ]
 
 -- | Helper to test an immutable read operation and verify the result.
@@ -174,11 +172,11 @@ testImmutableRead ::
 testImmutableRead repr name chunks readAddr memRepr expected = testCase name $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
-    let memChunks = [(base, mkChunk cache bytes CL.Immutable) | (base, bytes) <- chunks]
+    let memChunks = [(base, mkChunk bytes CL.Immutable) | (base, bytes) <- chunks]
     let imap = mkIntervalMap memChunks
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym repr readAddr
-    res <- concreteImmutableGlobalRead sym imap globalBlk memRepr ptr
+    res <- concreteImmutableGlobalRead sym imap cache globalBlk memRepr ptr
     pure $ case res of
       Nothing -> Nothing
       Just val -> extractLEBytes val (fromIntegral $ MC.memReprBytes memRepr)
@@ -277,11 +275,11 @@ wrongBlockReturnsNothing :: TestTree
 wrongBlockReturnsNothing = testCase "Wrong block returns Nothing" $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
-    let chunk = mkChunk cache [0xAA, 0xBB] CL.Immutable
+    let chunk = mkChunk [0xAA, 0xBB] CL.Immutable
     let imap = mkIntervalMap @32 [(100, chunk)]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkPtr sym MC.Addr32 2 100  -- block 2, but global is block 1
-    r <- concreteImmutableGlobalRead sym imap globalBlk bv1 ptr
+    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv1 ptr
     pure (isNothing r)
   assertBool "wrong block should return Nothing" result
 
@@ -289,13 +287,13 @@ symbolicOffsetReturnsNothing :: TestTree
 symbolicOffsetReturnsNothing = testCase "Symbolic offset returns Nothing" $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
-    let chunk = mkChunk cache [0xAA, 0xBB] CL.Immutable
+    let chunk = mkChunk [0xAA, 0xBB] CL.Immutable
     let imap = mkIntervalMap @32 [(100, chunk)]
     globalBlk <- WI.natLit sym globalBlock
     blkSym <- WI.natLit sym globalBlock
     offSym <- WI.freshConstant sym (WI.safeSymbol "off") (WI.BaseBVRepr (WI.knownNat @32))
     let ptr = CLP.LLVMPointer blkSym offSym
-    r <- concreteImmutableGlobalRead sym imap globalBlk bv1 ptr
+    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv1 ptr
     pure (isNothing r)
   assertBool "symbolic offset should return Nothing" result
 
@@ -303,11 +301,11 @@ mutableRegionReturnsNothing :: TestTree
 mutableRegionReturnsNothing = testCase "Mutable region returns Nothing" $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
-    let chunk = mkChunk cache [0xAA, 0xBB] CL.Mutable
+    let chunk = mkChunk [0xAA, 0xBB] CL.Mutable
     let imap = mkIntervalMap @32 [(100, chunk)]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym MC.Addr32 100
-    r <- concreteImmutableGlobalRead sym imap globalBlk bv1 ptr
+    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv1 ptr
     pure (isNothing r)
   assertBool "mutable region should return Nothing" result
 
@@ -323,15 +321,15 @@ nonContiguousRegionsReturnsNothing :: TestTree
 nonContiguousRegionsReturnsNothing = testCase "Non-contiguous regions returns Nothing" $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
-    let chunk1 = mkChunk cache [0xAA] CL.Immutable
-    let chunk2 = mkChunk cache [0xBB] CL.Immutable
+    let chunk1 = mkChunk [0xAA] CL.Immutable
+    let chunk2 = mkChunk [0xBB] CL.Immutable
     let imap = IM.fromList
           [ (IMI.IntervalCO (100 :: MC.MemWord 32) 101, chunk1)
           , (IMI.IntervalCO 102 103, chunk2)
           ]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym MC.Addr32 100
-    r <- concreteImmutableGlobalRead sym imap globalBlk bv2 ptr
+    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv2 ptr
     pure (isNothing r)
   assertBool "non-contiguous regions should return Nothing" result
 
@@ -355,8 +353,8 @@ readAdjacentMutableChunkReturnsJust :: TestTree
 readAdjacentMutableChunkReturnsJust = testCase "Read with adjacent mutable chunk returns Just" $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
-    let immChunk = mkChunk cache [0xAA, 0xBB] CL.Immutable
-    let mutChunk = mkChunk cache [0xCC, 0xDD] CL.Mutable
+    let immChunk = mkChunk [0xAA, 0xBB] CL.Immutable
+    let mutChunk = mkChunk [0xCC, 0xDD] CL.Mutable
     -- [100, 102) immutable, [102, 104) mutable
     let imap = IM.fromList
           [ (IMI.IntervalCO (100 :: MC.MemWord 32) 102, immChunk)
@@ -364,7 +362,7 @@ readAdjacentMutableChunkReturnsJust = testCase "Read with adjacent mutable chunk
           ]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym MC.Addr32 100
-    r <- concreteImmutableGlobalRead sym imap globalBlk bv2 ptr
+    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv2 ptr
     pure $ case r of
       Nothing -> Nothing
       Just val -> extractLEBytes val 2
@@ -464,13 +462,12 @@ sliceBytes bs offset len = BS.unpack $ BS.take len $ BS.drop (fromIntegral offse
 -- | Build an IntervalMap from a MemorySpace.
 -- Extracts bytes from the ByteString and creates symbolic chunks.
 memorySpaceToIntervalMap ::
-  ByteCache sym ->
   MemorySpace ->
   IM.IntervalMap (MC.MemWord 32) (SymbolicMemChunk sym)
-memorySpaceToIntervalMap cache memSpace =
+memorySpaceToIntervalMap memSpace =
   let chunks =
         [ ( word32ToWord64 (mcsBaseAddr s)
-          , mkChunk cache chunkBytes (mcsMutability s) )
+          , mkChunk chunkBytes (mcsMutability s) )
         | s <- msChunks memSpace
         , let chunkBytes = sliceBytes (msBytes memSpace) (mcsBaseAddr s) (mcsLength s)
         ]
@@ -550,7 +547,7 @@ prop_concreteImmutableGlobalRead = testPropertyNamed
     -- Return either Nothing (function declined) or Just (list of bytes).
     result <- evalIO $ withSym $ \sym -> do
       cache <- mkByteCache sym
-      let imap = memorySpaceToIntervalMap cache memSpace
+      let imap = memorySpaceToIntervalMap memSpace
       globalBlk <- WI.natLit sym globalBlock
       ptr <- mkPtr sym MC.Addr32 (rrBlockNum req) (word32ToWord64 (rrOffset req))
 
@@ -559,7 +556,7 @@ prop_concreteImmutableGlobalRead = testPropertyNamed
           Nothing -> fail $ "bvMemReprForSize failed for size " ++ show (rrSize req) ++ " (generator bug)"
           Just r -> pure r
 
-      r <- concreteImmutableGlobalRead sym imap globalBlk repr ptr
+      r <- concreteImmutableGlobalRead sym imap cache globalBlk repr ptr
       pure $ case r of
         Nothing -> Nothing
         Just v -> extractLEBytes v (rrSize req)


### PR DESCRIPTION
Previously, we were generating 1024-element `Seq`s of pointers to `SymBV sym 8`s covering the target's address space at program load time. This is actually a fair amount of overhead. On a 64-bit system, it's at least 8x (one 64-bit pointer per byte), likely considerably more due to the overhead of the finger tree backing the `Seq`. We then serviced reads from immutable memory by concatenating these 1024-size `Seq`s together, only to immediately slice out a maximum of 8 elements from the concatenated 2048-element sequence.

This commit never materializes `Seq`s, instead storing `ByteString`s (i.e., slices) that point directly to the data from the ELF (they don't even cause a `memcpy`). When servicing immutable reads at simulation time, we simply slice out the bytes we need, generating very short-lived `SymBV sym 8`s from the `ByteCache` on the fly. Not concatenating also allows us to use `Vec`s for the truly symbolic bytes (i.e., relocations), eliminating the fingertree overhead.

Peak residency of a downstream app (Screach) drops from ~6GB to ~220MB on a representative target.

Possible future work:

- Checking if `populateRelocation` returned concrete bytes and making a `ByteString` region if so
- Coalescing adjacent regions before chunking
- Adding a fast path that directly creates a `bvLit` if the read falls within a single `ByteString` region, without materializing the intermediate bytes
