### PR TITLE
Introduce shared `ByteCache`

### DIFF
--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -26,7 +26,7 @@ library
     prettyprinter >= 1.7.0,
     split,
     text,
-    vector,
+    vector >= 0.13.2,
     bytestring,
     what4 >= 1.1 && < 1.8
 
@@ -46,6 +46,7 @@ library
   other-modules:
     Data.Macaw.Symbolic.Bitcast
     Data.Macaw.Symbolic.CrucGen
+    Data.Macaw.Symbolic.Memory.ByteCache
     Data.Macaw.Symbolic.Memory.Common
     Data.Macaw.Symbolic.Panic
     Data.Macaw.Symbolic.PersistentState

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -139,6 +139,7 @@ import qualified Data.IntervalMap.Strict as IM
 
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Memory.Permissions as MMP
+import qualified Data.Macaw.Symbolic.Memory.ByteCache as MBC
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.LLVM.DataLayout as CLD
 import qualified Lang.Crucible.LLVM.MemModel as CL
@@ -280,7 +281,10 @@ newMergedGlobalMemoryWith hooks proxy bak endian mmc mems = do
                          "Global memory for macaw-symbolic"
                          memImpl1 sizeBV CLD.noAlignment
 
-  (symArray2, tbl) <- populateMemory proxy hooks bak mmc mems symArray1
+  -- Create the shared byte cache once (all 256 possible byte values)
+  cache <- liftIO $ MBC.mkByteCache sym
+
+  (symArray2, tbl) <- populateMemory proxy cache hooks bak mmc mems symArray1
   memImpl3 <- liftIO $ CL.doArrayStore bak memImpl2 ptr CLD.noAlignment symArray2 sizeBV
   let ptrTable = MemPtrTable { memPtrTable = tbl, memPtr = ptr }
 
@@ -340,6 +344,8 @@ populateMemory :: ( CB.IsSymBackend sym bak
                   )
                => proxy arch
                -- ^ A proxy to fix the architecture
+               -> MBC.ByteCache sym
+               -- ^ Shared cache of all 256 possible byte literals
                -> MSMC.GlobalMemoryHooks (MC.ArchAddrWidth arch)
                -- ^ Hooks controlling how memory should be initialized
                -> bak
@@ -352,11 +358,11 @@ populateMemory :: ( CB.IsSymBackend sym bak
                -> m ( WI.SymArray sym (CT.SingleCtx (WI.BaseBVType (MC.ArchAddrWidth arch))) (WI.BaseBVType 8)
                     , IM.IntervalMap (MC.MemWord (MC.ArchAddrWidth arch)) CL.Mutability
                     )
-populateMemory proxy hooks bak mmc mems symArray0 =
+populateMemory proxy cache hooks bak mmc mems symArray0 =
   MSMC.pleatM (symArray0, IM.empty) mems $ \allocs0 mem ->
     MSMC.pleatM allocs0 (MC.memSegments mem) $ \allocs1 seg -> do
       MSMC.pleatM allocs1 (MC.relativeSegmentContents [seg]) $ \(symArray, allocs2) (addr, memChunk) -> do
-        concreteBytes <- MSMC.populateMemChunkBytes bak hooks mem seg addr memChunk
+        concreteBytes <- MSMC.populateMemChunkBytes cache bak hooks mem seg addr memChunk
         populateSegmentChunk proxy bak mmc mem symArray seg addr concreteBytes allocs2
 
 -- | If we want to treat the contents of this chunk of memory (the bytes at the

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/ByteCache.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/ByteCache.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | A cache of all 256 possible byte literals (0x00 to 0xFF).
+--
+-- This module provides a strict, pre-computed cache of literal byte values as
+-- What4 terms to avoid allocating separate terms for each byte during memory
+-- operations. For large binaries, this optimization saves gigabytes of heap.
+module Data.Macaw.Symbolic.Memory.ByteCache
+  ( ByteCache
+  , mkByteCache
+  , indexByteCache
+  , indexByteCacheM
+  ) where
+
+import qualified Data.BitVector.Sized as BV
+import qualified Data.Vector.Strict as Vec
+import           Data.Word (Word8)
+import qualified What4.Interface as WI
+
+-- | A cache of all 256 possible byte literals @0x00@ to @0xFF@.
+--
+-- Constructor not exported to uphold safety invariant of 'indexByteCache'.
+newtype ByteCache sym = ByteCache (Vec.Vector (WI.SymBV sym 8))
+
+-- | Create a 'ByteCache'
+--
+-- Ideally, this should be called once during memory model initialization and
+-- the resulting cache should be shared across all operations.
+mkByteCache ::
+  WI.IsExprBuilder sym =>
+  sym ->
+  IO (ByteCache sym)
+mkByteCache sym = do
+  let w8 = WI.knownNat @8
+  cache <- Vec.generateM 256 $ \i ->
+    WI.bvLit sym w8 (BV.word8 (fromIntegral i))
+  pure (ByteCache cache)
+
+-- | Index into the 'ByteCache' to retrieve a symbolic bitvector.
+--
+-- This uses unsafe indexing internally since we know:
+--
+-- 1. The underlying 'Vec.Vector' has exactly 256 elements (0x00 to 0xFF)
+-- 2. 'Word8' values are always in the range @[0, 255]@
+--
+-- Therefore, the index is always in bounds and the bounds check is redundant.
+indexByteCache :: ByteCache sym -> Word8 -> WI.SymBV sym 8
+indexByteCache (ByteCache vec) byte = Vec.unsafeIndex vec (fromIntegral byte)
+{-# INLINE indexByteCache #-}
+
+-- | Monadic version of 'indexByteCache' that is strict in the vector.
+indexByteCacheM :: Monad m => ByteCache sym -> Word8 -> m (WI.SymBV sym 8)
+indexByteCacheM (ByteCache vec) byte = Vec.unsafeIndexM vec (fromIntegral byte)
+{-# INLINE indexByteCacheM #-}

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Common.hs
@@ -41,6 +41,7 @@ import qualified Data.Vector as Vec
 
 import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Macaw.CFG as MC
+import qualified Data.Macaw.Symbolic.Memory.ByteCache as MBC
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.LLVM.DataLayout as CLD
 import qualified Lang.Crucible.LLVM.MemModel as CL
@@ -272,14 +273,15 @@ populateMemChunkBytes ::
      , CB.IsSymBackend sym bak
      , MC.MemWidth w
      )
-  => bak
+  => MBC.ByteCache sym
+  -> bak
   -> GlobalMemoryHooks w
   -> MC.Memory w
   -> MC.MemSegment w
   -> MC.MemAddr w
   -> MC.MemChunk w
   -> m [WI.SymBV sym 8]
-populateMemChunkBytes bak hooks mem seg addr memChunk =
+populateMemChunkBytes cache bak hooks mem seg addr memChunk =
   liftIO $
   case memChunk of
     MC.RelocationRegion reloc ->
@@ -287,13 +289,10 @@ populateMemChunkBytes bak hooks mem seg addr memChunk =
     MC.BSSRegion sz ->
       replicate (fromIntegral sz) <$> WI.bvLit sym w8 (BV.zero w8)
     MC.ByteRegion bytes -> do
-      -- Cache all 256 possible byte literals to avoid allocating a fresh
-      -- SemiRingLiteral (+ SemiRingBVRepr + Integer + ProgramLoc) per byte.
-      -- For large binaries this saves gigabytes of heap.
-      cache <- Vec.generateM 256 $ \i ->
-        WI.bvLit sym w8 (BV.word8 (fromIntegral i))
-      -- Force to prevent thunk buildup, which would otherwise be considerable.
-      traverse (evaluate . (cache Vec.!) . fromIntegral) (BS.unpack bytes)
+      -- Use the shared byte cache to avoid allocating fresh SemiRingLiteral
+      -- terms for each byte. For large binaries this saves gigabytes of heap.
+      -- Force evaluation to prevent thunk buildup.
+      traverse (MBC.indexByteCacheM cache) (BS.unpack bytes)
   where
     sym = CB.backendGetSym bak
     w8 = WI.knownNat @8

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy.hs
@@ -61,6 +61,7 @@ import qualified Data.Parameterized.Context as Ctx
 import qualified Data.Parameterized.Vector as PV
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Memory.Permissions as MMP
+import qualified Data.Macaw.Symbolic.Memory.ByteCache as MBC
 import qualified Lang.Crucible.Backend as CB
 import qualified Lang.Crucible.Backend.Online as CBO
 import qualified Lang.Crucible.Backend.ProofGoals as CBP
@@ -161,6 +162,8 @@ data MemPtrTable sym w = MemPtrTable
   , memModelContents :: MSMC.MemoryModelContents
   -- ^ How to populate bytes in writable regions of static memory in the
   -- 'memPtrArray'.
+  , byteCache :: MBC.ByteCache sym
+  -- ^ See "Data.Macaw.Symbolic.Memory.ByteCache"
   }
 
 -- | A discrete chunk of a memory segment within global memory. Memory is
@@ -546,13 +549,17 @@ newMergedGlobalMemoryWith hooks _proxy bak endian mmc mems = do
                          "Global memory for macaw-symbolic"
                          memImpl1 sizeBV CLD.noAlignment
 
-  tbl <- mergedMemorySymbolicMemChunks bak hooks mems
+  cache <- liftIO $ MBC.mkByteCache sym
+
+  tbl <- mergedMemorySymbolicMemChunks cache bak hooks mems
+
   memImpl3 <- liftIO $ CL.doArrayStore bak memImpl2 ptr CLD.noAlignment symArray sizeBV
   let ptrTable = MemPtrTable
                    { memPtrTable = tbl
                    , memPtr = ptr
                    , memPtrArray = symArray
                    , memModelContents = mmc
+                   , byteCache = cache
                    }
 
   return (memImpl3, ptrTable)
@@ -568,11 +575,12 @@ mergedMemorySymbolicMemChunks ::
   , Traversable t
   , MonadIO m
   ) =>
+  MBC.ByteCache sym ->
   bak ->
   MSMC.GlobalMemoryHooks w ->
   t (MC.Memory w) ->
   m (IM.IntervalMap (MC.MemWord w) (SymbolicMemChunk sym))
-mergedMemorySymbolicMemChunks bak hooks mems =
+mergedMemorySymbolicMemChunks cache bak hooks mems =
   fmap (IM.fromList . concat) $ traverse memorySymbolicMemChunks mems
   where
     memorySymbolicMemChunks ::
@@ -588,7 +596,7 @@ mergedMemorySymbolicMemChunks bak hooks mems =
     segmentSymbolicMemChunks mem seg = concat <$>
       traverse
         (\(addr, chunk) -> do
-          allBytes <- MSMC.populateMemChunkBytes bak hooks mem seg addr chunk
+          allBytes <- MSMC.populateMemChunkBytes cache bak hooks mem seg addr chunk
           let mut | MMP.isReadonly (MC.segmentFlags seg) = CL.Immutable
                   | otherwise                            = CL.Mutable
           let absAddr =


### PR DESCRIPTION
Abstracts a caching pattern that was used in the memory model to avoid duplicate concrete `SymBV sym 8`s. Threading through a `newtype`'d cache guarantees that we allocate all the bytes exactly once, addressing a performance concern that arose during review. Putting it in its own module allows unsafe indexing for better performance. Using a strict `Vec` ensures WHNF elements, fixing #564.