### PR TITLE
Memory model: optimize reads from unpopulated mutable chunks

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -128,7 +128,7 @@ module Data.Macaw.Symbolic
   , unsupportedSyscalls
   , MO.LookupSyscallHandle(..)
   , ResolvePointer
-  , ConcreteImmutableGlobalRead
+  , ConcreteUnmutatedGlobalRead
   , LazilyPopulateGlobalMem
   , MO.MacawSimulatorState(..)
   , MO.MacawLazySimulatorState(..)
@@ -1109,13 +1109,16 @@ unsupportedSyscalls compName =
 -- returning the original pointer unchanged if this cannot be done.
 type ResolvePointer sym w = MM.LLVMPtr sym w -> IO (MM.LLVMPtr sym w)
 
--- | If reading a value of type @ty@ from a concrete and immutable (i.e.,
--- read-only) section of the global address space, then returning @Just val@
+-- | If reading a value of type @ty@ from a concrete address in the global
+-- address space where concrete bytes are available, then returning @Just val@
 -- will bypass having to perform a full read from the underlying memory model.
--- Bypassing a full read is likely to be more performant.
-type ConcreteImmutableGlobalRead sym w =
+-- Bypassing a full read is likely to be more performant. This works for
+-- unmutated chunks (immutable chunks and mutable chunks that haven't been
+-- written to yet).
+type ConcreteUnmutatedGlobalRead p sym w =
      forall ty
-   . M.MemRepr ty
+   . p
+  -> M.MemRepr ty
   -> MM.LLVMPtr sym w
   -> IO (Maybe (C.RegValue sym (PS.ToCrucibleType ty)))
 
@@ -1148,19 +1151,20 @@ data MemModelConfig p sym arch mem = MemModelConfig
   , mkGlobalPointerValidityAssertion :: MkGlobalPointerValidityAssertion sym (M.ArchAddrWidth arch)
     -- ^ A function to make memory validity predicates (see
     -- 'MkGlobalPointerValidityAssertion' for details).
-  , concreteImmutableGlobalRead :: ConcreteImmutableGlobalRead sym (M.ArchAddrWidth arch)
-    -- ^ If reading a value of type @ty@ from a concrete and immutable (i.e.,
-    -- read-only) section of the global address space, you can return
+  , concreteUnmutatedGlobalRead :: ConcreteUnmutatedGlobalRead p sym (M.ArchAddrWidth arch)
+    -- ^ If reading a value of type @ty@ from a concrete address in the
+    -- global address space where concrete bytes are available, you can return
     -- @Just val@ here to bypass having to perform a full read from the
     -- underlying memory model. Bypassing a full read is likely to be more
-    -- performant. For instance, the lazy memory model makes use of this
-    -- option—see @Note [Lazy memory model]@ in
+    -- performant. This works for unmutated chunks (immutable chunks and
+    -- mutable chunks that haven't been written to yet). For instance, the lazy
+    -- memory model makes
+    -- use of this option—see @Note [Lazy memory model]@ in
     -- "Data.Macaw.Symbolic.Memory.Lazy".
     --
     -- Note that it is always fine to return 'Nothing' as a default
-    -- implementation, even when reading from concrete, immutable sections of
-    -- the global address space. The only thing that will be impacted is
-    -- performance.
+    -- implementation, even when reading from concrete global memory. The
+    -- only thing that will be impacted is performance.
   , lazilyPopulateGlobalMem :: LazilyPopulateGlobalMem p sym (MacawExt arch) (M.ArchAddrWidth arch)
     -- ^ The memory model will call this function just before performing a full
     -- read or write, which allows users to modify the simulator state based on
@@ -1246,7 +1250,7 @@ note the following differences:
 
 * 'MO.doReadMem' unconditionally reads from memory, whereas 'doReadMemModel'
   may skip reading from memory and instead return a result directly if the
-  'MemModelConfig' is configured to do so. (See 'concreteImmutableGlobalRead'.)
+  'MemModelConfig' is configured to do so. (See 'concreteUnmutatedGlobalRead'.)
   Similarly for 'MO.doCondReadMem' versus 'doCondReadMemModel'.
 
 * 'MO.doReadMem' never modifies the 'C.SimState', whereas 'doReadMemModel'
@@ -1287,7 +1291,7 @@ doReadMemModel mvar mmConf addrWidth memRep ptr0 st0 =
     mem <- getMem st0 mvar
     ptr1 <- tryGlobPtr bak mem globs (C.regValue ptr0)
     ptr2 <- resolvePointer mmConf ptr1
-    mbReadVal <- concreteImmutableGlobalRead mmConf memRep ptr2
+    mbReadVal <- concreteUnmutatedGlobalRead mmConf (st0 ^. C.stateContext . C.cruciblePersonality) memRep ptr2
     case mbReadVal of
       Just readVal -> pure (readVal, st0)
       Nothing -> do
@@ -1322,7 +1326,7 @@ doCondReadMemModel mvar mmConf addrWidth memRep cond ptr0 condFalseValue st0 =
     mem <- getMem st0 mvar
     ptr1 <- tryGlobPtr bak mem globs (C.regValue ptr0)
     ptr2 <- resolvePointer mmConf ptr1
-    mbReadVal <- concreteImmutableGlobalRead mmConf memRep ptr2
+    mbReadVal <- concreteUnmutatedGlobalRead mmConf (st0 ^. C.stateContext . C.cruciblePersonality) memRep ptr2
     case mbReadVal of
       Just readVal -> do
         readVal' <- muxMemReprValue sym memRep (C.regValue cond) readVal (C.regValue condFalseValue)

--- a/symbolic/src/Data/Macaw/Symbolic/Memory.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory.hs
@@ -167,8 +167,8 @@ import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 -- * No attempt is made to to concretize pointers. That is, 'MS.resolvePointer'
 --   will simply return its pointer argument unchanged.
 --
--- * No special treatment is given to concrete reads from read-only memory.
---   That is, 'MS.concreteImmutableGlobalRead' always returns 'Nothing'.
+-- * No special treatment is given to concrete reads from unmutated memory.
+--   That is, 'MS.concreteUnmutatedGlobalRead' always returns 'Nothing'.
 --
 -- * The memory model does not perform incremental updates before reads or
 --   writes. That is, 'MS.lazilyPopulateGlobalMem' always returns its state
@@ -192,7 +192,7 @@ memModelConfig _ mpt =
     , MS.lookupSyscallHandle = MS.unsupportedSyscalls origin
     , MS.mkGlobalPointerValidityAssertion = mkGlobalPointerValidityPred mpt
     , MS.resolvePointer = pure
-    , MS.concreteImmutableGlobalRead = \_ _ -> pure Nothing
+    , MS.concreteUnmutatedGlobalRead = \_ _ _ -> pure Nothing
     , MS.lazilyPopulateGlobalMem = \_ _ -> pure
     }
   where

--- a/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy/Internal.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Memory/Lazy/Internal.hs
@@ -12,7 +12,7 @@
 -- | Internal module for "Data.Macaw.Symbolic.Memory.Lazy".
 --
 -- This module exposes all internals for testing purposes.
--- Mainly, we want to test 'concreteImmutableGlobalRead'.
+-- Mainly, we want to test 'concreteUnmutatedGlobalRead'.
 --
 -- The public API is re-exported by "Data.Macaw.Symbolic.Memory.Lazy".
 module Data.Macaw.Symbolic.Memory.Lazy.Internal (
@@ -38,7 +38,8 @@ module Data.Macaw.Symbolic.Memory.Lazy.Internal (
   readBytesAsBV,
   concatBytes,
   mergedMemorySymbolicMemChunks,
-  concreteImmutableGlobalRead,
+  concreteUnmutatedGlobalRead,
+  concreteUnmutatedGlobalReadWithPopulatedChunks,
   lazilyPopulateGlobalMemArr,
   symBVInterval,
   mulMono,
@@ -103,8 +104,8 @@ import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 --   online SMT solver connection in an effort to concretize the pointer being
 --   read from or written to.
 --
--- * 'MS.concreteImmutableGlobalRead' will use the supplied 'MemPtrTable' to
---   detect concrete reads from read-only memory, in which case the
+-- * 'MS.concreteUnmutatedGlobalRead' will use the supplied 'MemPtrTable' to
+--   detect concrete reads from unmutated memory, in which case the
 --   'memPtrArray' will be bypassed for efficiency reasons.
 --
 -- * 'MS.lazilyPopulateGlobalMem' is used to incrementally populate the
@@ -143,7 +144,7 @@ memModelConfig bak mpt =
     , MS.lookupSyscallHandle = MS.unsupportedSyscalls origin
     , MS.mkGlobalPointerValidityAssertion = mkGlobalPointerValidityPred mpt
     , MS.resolvePointer = MSC.resolveLLVMPtr bak
-    , MS.concreteImmutableGlobalRead = concreteImmutableGlobalRead sym (memPtrTable mpt) (byteCache mpt) (CLP.llvmPointerBlock (memPtr mpt))
+    , MS.concreteUnmutatedGlobalRead = concreteUnmutatedGlobalRead sym (memPtrTable mpt) (byteCache mpt) (CLP.llvmPointerBlock (memPtr mpt))
     , MS.lazilyPopulateGlobalMem = lazilyPopulateGlobalMemArr bak mpt
     }
   where
@@ -307,8 +308,9 @@ extendUpperBound i extendBy =
 --      addr                             addr + numBytes
 -- @
 --
--- Returns 'Just' if the chunks are contiguous, all immutable, and cover the
--- full read window. Returns 'Nothing' otherwise.
+-- Returns 'Just' if the chunks are contiguous, immutable or mutable but
+-- unpopulated, and cover the full read window. Returns 'Nothing' otherwise.
+-- Chunks are valid if they are immutable OR mutable but unpopulated.
 sliceContiguousChunks ::
   forall a sym.
   (Eq a, Integral a) =>
@@ -317,15 +319,17 @@ sliceContiguousChunks ::
   -- ^ The address being read from
   Int ->
   -- ^ Number of bytes to read
+  IS.IntervalSet (IMI.Interval a) ->
+  -- ^ Populated chunks (we cannot use mutable chunks in this set)
   [(IMI.Interval a, SymbolicMemChunk sym)] ->
   Maybe [WI.SymBV sym 8]
-sliceContiguousChunks cache addr numBytes =
+sliceContiguousChunks cache addr numBytes populatedChunks =
   \case
     _ | numBytes <= 0 -> Just []
     [] -> Nothing
     ((firstI, firstC) : rest) -> do
       guard (addr >= IMI.lowerBound firstI)
-      guard (smcMutability firstC == CL.Immutable)
+      guard (validChunk firstI firstC)
       let skip = convert (addr - IMI.lowerBound firstI)
           firstLen = intervalLen firstI
           avail = firstLen - skip
@@ -336,6 +340,12 @@ sliceContiguousChunks cache addr numBytes =
       go firstI remaining trimmedFirst rest
   where
     convert = fromIntegral @a @Int
+
+    validChunk :: IMI.Interval a -> SymbolicMemChunk sym -> Bool
+    validChunk interval chunk =
+      case smcMutability chunk of
+        CL.Immutable -> True
+        CL.Mutable -> interval `IS.notMember` populatedChunks
 
     -- We expect IntervalCOs
     intervalLen :: IMI.Interval a -> Int
@@ -367,7 +377,7 @@ sliceContiguousChunks cache addr numBytes =
       [] -> Nothing
       ((ival, chunk) : rest) -> do
         guard (checkContiguous prev ival)
-        guard (smcMutability chunk == CL.Immutable)
+        guard (validChunk ival chunk)
         let chunkLen = intervalLen ival
         let remaining' = remaining - chunkLen
         -- (++) is O(n^2), but these lists are a maximum of 8 elements (bytes)
@@ -720,12 +730,15 @@ mergedMemorySymbolicMemChunks bak hooks mems =
 
 
 -- Return @Just val@ if we can be absolutely sure that this is a concrete
--- read from a contiguous region of immutable, global memory, where the type of
+-- read from a contiguous region of unmutated global memory, where the type of
 -- @val@ is determined by the @'MC.MemRepr' ty@ argument.
 -- Return @Nothing@ otherwise. See @Note [Lazy memory model]@.
-concreteImmutableGlobalRead ::
-  forall sym w.
-  (CB.IsSymInterface sym, MC.MemWidth w) =>
+concreteUnmutatedGlobalRead ::
+  forall sym w p.
+  ( CB.IsSymInterface sym
+  , MC.MemWidth w
+  , MS.HasMacawLazySimulatorState p sym w
+  ) =>
   sym ->
   IM.IntervalMap (MC.MemWord w) (SymbolicMemChunk sym) ->
   -- ^ The interval map of global memory chunks
@@ -733,8 +746,25 @@ concreteImmutableGlobalRead ::
   -- ^ Byte cache for creating symbolic expressions on demand
   WI.SymNat sym ->
   -- ^ The global memory block number
-  MS.ConcreteImmutableGlobalRead sym w
-concreteImmutableGlobalRead sym imap cache memPtrBlk memRep ptr
+  MS.ConcreteUnmutatedGlobalRead p sym w
+concreteUnmutatedGlobalRead sym imap cache memPtrBlk personality =
+  let popChunks = personality ^. MS.populatedMemChunks in
+  concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache memPtrBlk popChunks
+
+concreteUnmutatedGlobalReadWithPopulatedChunks ::
+  forall sym w ty.
+  ( CB.IsSymInterface sym
+  , MC.MemWidth w
+  ) =>
+  sym ->
+  IM.IntervalMap (MC.MemWord w) (SymbolicMemChunk sym) ->
+  MBC.ByteCache sym ->
+  WI.SymNat sym ->
+  IS.IntervalSet (IMI.Interval (MC.MemWord w)) ->
+  MC.MemRepr ty ->
+  CL.LLVMPtr sym w ->
+  IO (Maybe (CS.RegValue sym (MS.ToCrucibleType ty)))
+concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache memPtrBlk populatedChunks memRep ptr
   | -- First, check that the pointer being read from is concrete.
     Just ptrBlkNat <- WI.asNat ptrBlk
   , Just addrBV    <- WI.asBV ptrOff
@@ -744,13 +774,13 @@ concreteImmutableGlobalRead sym imap cache memPtrBlk memRep ptr
   , Just memPtrBlkNat <- WI.asNat memPtrBlk
   , ptrBlkNat == memPtrBlkNat
 
-    -- Next, look up the chunks that intersect the read range and try to
-    -- extract contiguous, immutable bytes covering the full read.
+    -- Next, look up the chunks that intersect the read range and try to extract
+    -- contiguous, unmutated bytes covering the full read.
   , let addr = fromInteger @(MC.MemWord w) $ BV.asUnsigned addrBV
   , let endAddr = addr + fromIntegral @Int @(MC.MemWord w) numBytes
   , let chunks = IM.toAscList $
           imap `IM.intersecting` IMI.IntervalCO addr endAddr
-  , Just bytes <- sliceContiguousChunks cache addr numBytes chunks
+  , Just bytes <- sliceContiguousChunks cache addr numBytes populatedChunks chunks
   = do readVal <- readBytesAsRegValue sym memRep bytes
        pure $ Just readVal
 
@@ -1014,17 +1044,17 @@ two important optimizations:
    that is the right value to be properly aligned on most architectures.
 
 2. While tracking the writable global memory in an SMT array is important in
-   case the memory gets updated, there's really no need to track the
-   read-only global memory in an SMT array. After all, read-only memory can
-   never be updated, so we can determine what read-only memory will be by
-   looking up the corresponding bytes in the IntervalMap, bypassing the SMT
-   array completely.
+   case the memory gets updated, there's really no need to track the read-only
+   global memory in an SMT array, nor to track writable memory that has not
+   yet been mutated. We can determine what unmutated memory will be by looking
+   up the corresponding bytes in the IntervalMap, bypassing the SMT array
+   completely.
 
    To determine which parts of memory are read-only, each `SymbolicMemChunk`
    tracks whether its bytes are mutable or immutable. When performing a memory
    read, if we can conclude that all of the memory to be read is immutable
-   (i.e., read-only), then we can convert the symbolic bytes to a bitvector.
-   (See `readBytesAsRegValue` for how this is implemented.)
+   (i.e., read-only) or not yet written, then we can convert the symbolic bytes
+   to a bitvector. (See `readBytesAsRegValue` for how this is implemented.)
 
    There are several criteria that must be met in order for this to be
    possible:
@@ -1032,7 +1062,7 @@ two important optimizations:
    * The read must be concrete.
 
    * The amount of bytes to be read must lie within a contiguous part of
-     read-only memory.
+     unmutated memory.
 
    * There must be enough bytes within this part of memory to cover the number
      of bytes that must be read.

--- a/symbolic/test/Lazy.hs
+++ b/symbolic/test/Lazy.hs
@@ -16,6 +16,7 @@ import qualified Data.BitVector.Sized as BV
 import qualified Data.ByteString as BS
 import qualified Data.IntervalMap.Strict as IM
 import qualified Data.IntervalMap.Interval as IMI
+import qualified Data.IntervalSet as IS
 import           Data.Maybe (isJust, isNothing)
 import           Data.Word (Word8, Word32, Word64)
 import           Numeric.Natural (Natural)
@@ -159,7 +160,7 @@ testImmutableRead repr name chunks readAddr memRepr expected = testCase name $ d
     let imap = mkIntervalMap memChunks
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym repr readAddr
-    res <- concreteImmutableGlobalRead sym imap cache globalBlk memRepr ptr
+    res <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty memRepr ptr
     pure $ case res of
       Nothing -> Nothing
       Just val -> extractLEBytes val (fromIntegral $ MC.memReprBytes memRepr)
@@ -262,7 +263,7 @@ wrongBlockReturnsNothing = testCase "Wrong block returns Nothing" $ do
     let imap = mkIntervalMap @32 [(100, chunk)]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkPtr sym MC.Addr32 2 100  -- block 2, but global is block 1
-    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv1 ptr
+    r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty bv1 ptr
     pure (isNothing r)
   assertBool "wrong block should return Nothing" result
 
@@ -276,21 +277,37 @@ symbolicOffsetReturnsNothing = testCase "Symbolic offset returns Nothing" $ do
     blkSym <- WI.natLit sym globalBlock
     offSym <- WI.freshConstant sym (WI.safeSymbol "off") (WI.BaseBVRepr (WI.knownNat @32))
     let ptr = CLP.LLVMPointer blkSym offSym
-    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv1 ptr
+    r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty bv1 ptr
     pure (isNothing r)
   assertBool "symbolic offset should return Nothing" result
 
-mutableRegionReturnsNothing :: TestTree
-mutableRegionReturnsNothing = testCase "Mutable region returns Nothing" $ do
+unpopulatedMutableRegionReturnsJust :: TestTree
+unpopulatedMutableRegionReturnsJust = testCase "Unpopulated mutable region returns concrete bytes" $ do
   result <- withSym $ \sym -> do
     cache <- mkByteCache sym
     let chunk = mkChunk [0xAA, 0xBB] CL.Mutable
     let imap = mkIntervalMap @32 [(100, chunk)]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym MC.Addr32 100
-    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv1 ptr
+    r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty bv1 ptr
+    pure $ case r of
+      Nothing -> Nothing
+      Just val -> extractLEBytes val 1
+  result @?= Just [0xAA]
+
+populatedMutableRegionReturnsNothing :: TestTree
+populatedMutableRegionReturnsNothing = testCase "Populated mutable region returns Nothing" $ do
+  result <- withSym $ \sym -> do
+    cache <- mkByteCache sym
+    let chunk = mkChunk [0xAA, 0xBB] CL.Mutable
+    let imap = mkIntervalMap @32 [(100, chunk)]
+    globalBlk <- WI.natLit sym globalBlock
+    ptr <- mkGlobalPtr sym MC.Addr32 100
+    -- Mark the chunk as populated
+    let populated = IS.singleton (IMI.IntervalCO 100 102)
+    r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk populated bv1 ptr
     pure (isNothing r)
-  assertBool "mutable region should return Nothing" result
+  assertBool "populated mutable region should return Nothing" result
 
 notEnoughBytesReturnsNothing :: TestTree
 notEnoughBytesReturnsNothing = testImmutableRead MC.Addr32
@@ -312,7 +329,7 @@ nonContiguousRegionsReturnsNothing = testCase "Non-contiguous regions returns No
           ]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym MC.Addr32 100
-    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv2 ptr
+    r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty bv2 ptr
     pure (isNothing r)
   assertBool "non-contiguous regions should return Nothing" result
 
@@ -345,7 +362,7 @@ readAdjacentMutableChunkReturnsJust = testCase "Read with adjacent mutable chunk
           ]
     globalBlk <- WI.natLit sym globalBlock
     ptr <- mkGlobalPtr sym MC.Addr32 100
-    r <- concreteImmutableGlobalRead sym imap cache globalBlk bv2 ptr
+    r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty bv2 ptr
     pure $ case r of
       Nothing -> Nothing
       Just val -> extractLEBytes val 2
@@ -516,12 +533,12 @@ extractLEBytes ptr numBytes = do
        | i <- [0 .. numBytes - 1]
        ]
 
--- | Property: when concreteImmutableGlobalRead returns Just, the bytes match
+-- | Property: when concreteUnmutatedGlobalRead returns Just, the bytes match
 -- the actual memory contents.
-prop_concreteImmutableGlobalRead :: TestTree
-prop_concreteImmutableGlobalRead = testPropertyNamed
-  "concreteImmutableGlobalRead returns correct data"
-  "prop_concreteImmutableGlobalRead"
+prop_concreteUnmutatedGlobalRead :: TestTree
+prop_concreteUnmutatedGlobalRead = testPropertyNamed
+  "concreteUnmutatedGlobalRead returns correct data"
+  "prop_concreteUnmutatedGlobalRead"
   $ withTests 512 $ property $ do
     memSpace <- forAll genMemorySpace
     req <- forAll genReadRequest
@@ -539,7 +556,7 @@ prop_concreteImmutableGlobalRead = testPropertyNamed
           Nothing -> fail $ "bvMemReprForSize failed for size " ++ show (rrSize req) ++ " (generator bug)"
           Just r -> pure r
 
-      r <- concreteImmutableGlobalRead sym imap cache globalBlk repr ptr
+      r <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty repr ptr
       pure $ case r of
         Nothing -> Nothing
         Just v -> extractLEBytes v (rrSize req)
@@ -550,7 +567,7 @@ prop_concreteImmutableGlobalRead = testPropertyNamed
         let expectedBytes = sliceBytes (msBytes memSpace) (rrOffset req) (rrSize req)
         actualBytes === expectedBytes
 
--- | Property: concreteImmutableGlobalRead and mkGlobalPointerValidityPredCommon
+-- | Property: concreteUnmutatedGlobalRead and mkGlobalPointerValidityPredCommon
 -- must be consistent:
 --
 -- * If the read succeeds, the validity predicate must say True.
@@ -563,7 +580,7 @@ prop_concreteImmutableGlobalRead = testPropertyNamed
 -- past end of region). We only test when the block number matches.
 prop_readValidityConsistency :: TestTree
 prop_readValidityConsistency = testPropertyNamed
-  "concreteImmutableGlobalRead consistent with validity predicate"
+  "concreteUnmutatedGlobalRead consistent with validity predicate"
   "prop_readValidityConsistency"
   $ withTests 512 $ property $ do
     memSpace <- forAll genMemorySpace
@@ -583,7 +600,7 @@ prop_readValidityConsistency = testPropertyNamed
           Nothing -> fail $ "bvMemReprForSize failed for size " ++ show sz ++ " (generator bug)"
           Just r -> pure r
 
-      readResult <- concreteImmutableGlobalRead sym imap cache globalBlk repr ptr
+      readResult <- concreteUnmutatedGlobalReadWithPopulatedChunks sym imap cache globalBlk IS.empty repr ptr
 
       let mutMap = fmap smcMutability imap
       let ptrEntry = CS.RegEntry (CL.LLVMPointerRepr WI.knownNat) ptr
@@ -634,7 +651,8 @@ tests = testGroup "Lazy memory model"
       , testGroup "Failure cases"
           [ wrongBlockReturnsNothing
           , symbolicOffsetReturnsNothing
-          , mutableRegionReturnsNothing
+          , unpopulatedMutableRegionReturnsJust
+          , populatedMutableRegionReturnsNothing
           , notEnoughBytesReturnsNothing
           , nonContiguousRegionsReturnsNothing
           , overlappingRegionsReturnsNothing
@@ -646,7 +664,7 @@ tests = testGroup "Lazy memory model"
           ]
       ]
   , testGroup "Property-based tests"
-      [ prop_concreteImmutableGlobalRead
+      [ prop_concreteUnmutatedGlobalRead
       , prop_readValidityConsistency
       ]
   ]


### PR DESCRIPTION
Previously, for mutable chunks, `doReadMemModel` lazily populated memory and then immediately read symbolic bytes from it, even for concrete pointers.

After this commit, we just return concrete bytes for reads before writes to mutable chunks. There's no need to populate the SMT array if the memory is only read from concrete addresses.

Fixes #583.