### PR TITLE
perf(symbolic): read register struct less in `addRegUpdateForBlock`

### DIFF
--- a/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
@@ -1767,16 +1767,28 @@ at entry to the next block.
 -}
 addRegUpdateForBlock :: OrdF (M.ArchReg arch) => MacawSymbolicArchFunctions arch -> M.ArchSegmentOff arch -> CrucGen arch ids s ()
 addRegUpdateForBlock archFns startAddr = do
-  mp <- updatesFromRegStruct (crucGenRegAssignment archFns)
+  regReg <- gets crucRegisterReg
+  regStruct <- evalAtom (CR.ReadReg regReg)
+  idxMap <- gets crucRegIndexMap
+  let regTypes = crucArchRegTypes archFns
+  mp <- updatesFromRegStruct regStruct regTypes idxMap (crucGenRegAssignment archFns)
   void $ evalMacawStmt $ MacawArchStateUpdate (M.segoffAddr startAddr) mp
  where
   updatesFromRegStruct ::
     OrdF (M.ArchReg arch) =>
+    CR.Atom s (ArchRegStruct arch) ->
+    Assignment C.TypeRepr (MacawCrucibleRegTypes arch) ->
+    RegIndexMap arch ->
     Assignment (M.ArchReg arch) ctx ->
     CrucGen arch ids s (MapF.MapF (M.ArchReg arch) (MacawCrucibleValue (CR.Atom s)))
-  updatesFromRegStruct = foldlMFC' (\mp reg -> do
-    rval <- getRegValue reg
-    pure $ MapF.insert reg (MacawCrucibleValue rval) mp) MapF.empty
+  updatesFromRegStruct regStruct regTypes idxMap = foldlMFC' (\mp reg ->
+    case MapF.lookup reg idxMap of
+      Nothing -> fail "internal: Register is not bound."
+      Just idx -> do
+        let cidx = crucibleIndex idx
+        let tp = regTypes Ctx.! cidx
+        rval <- crucibleValue (C.GetStruct regStruct cidx tp)
+        pure $ MapF.insert reg (MacawCrucibleValue rval) mp) MapF.empty
 
 addParsedBlock :: forall arch ids s
                .  MacawSymbolicArchFunctions arch


### PR DESCRIPTION
`addRegUpdateForBlock` is responsible for producing `MacawArchStateUpdate` metadata statements in generated Crucible CFGs. Before this change, it called `getRegValue` for each architectural register. Each call emitted a redundant `ReadReg` atom to read the entire register struct from the mutable Crucible register. For x86-64 (~50 registers), this produced many duplicate `ReadReg` statements per basic block in the generated Crucible CFG.

Instead, read the struct once up front and extract each field from the cached atom. On a ~9MB x86 ELF binary (2665 functions, 70648 macaw blocks, 77828 crucible blocks), this reduces heap allocations by ~9.6% (573.8 GB -> 518.5 GB) and total runtime by ~7.5% (331.8s -> 306.9s). The generated Crucible statement counts are unchanged.