### PR TITLE
Allow doctest 0.23, 0.24, and 0.25 in macaw-symbolic

### DIFF
--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -65,7 +65,7 @@ test-suite doctests
   hs-source-dirs: test
   main-is: doctest.hs
   ghc-options: -Wall -Wcompat -threaded
-  build-depends: base, macaw-base, macaw-symbolic, doctest >= 0.10 && < 0.23
+  build-depends: base, macaw-base, macaw-symbolic, doctest >= 0.10 && < 0.26
 
 test-suite macaw-symbolic-tests
   type: exitcode-stdio-1.0


### PR DESCRIPTION
This comes up as part of SAW build plans using GHC 9.10 or 9.12.