### PR TITLE
symbolic: Encode abstract values into Crucible CFGs

### DIFF
--- a/base/macaw-base.cabal
+++ b/base/macaw-base.cabal
@@ -58,6 +58,7 @@ library
     Data.Macaw.AbsDomain.AbsState.Internal
     Data.Macaw.AbsDomain.CallParams
     Data.Macaw.AbsDomain.JumpBounds
+    Data.Macaw.AbsDomain.StackAnalysis
     Data.Macaw.AbsDomain.Refine
     Data.Macaw.AbsDomain.StridedInterval
     Data.Macaw.AbsDomain.StridedInterval.Internal
@@ -95,7 +96,6 @@ library
     Data.Macaw.Utils.Pretty
 
   other-modules:
-    Data.Macaw.AbsDomain.StackAnalysis
     Data.Macaw.Panic
 
   ghc-options: -Wall -Wcompat

--- a/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
+++ b/base/src/Data/Macaw/AbsDomain/JumpBounds.hs
@@ -19,13 +19,19 @@ known equivalent values.
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Data.Macaw.AbsDomain.JumpBounds
-  ( -- * Initial jump bounds
-    InitJumpBounds
+  ( -- * Range predicates
+    RangePred(..)
+  , rangeNotTotal
+  , SubRange(..)
+  , BlockStartRangePred
+    -- * Initial jump bounds
+  , InitJumpBounds
   , initBndsMap
+  , initRngPredMap
   , functionStartBounds
   , ppInitJumpBounds
   , joinInitialBounds
-    -- * IntraJumpbounds
+    -- * IntraJumpBounds
   , IntraJumpBounds
   , blockEndBounds
   , postCallBounds

--- a/symbolic/macaw-symbolic.cabal
+++ b/symbolic/macaw-symbolic.cabal
@@ -73,7 +73,7 @@ test-suite macaw-symbolic-tests
   default-language: Haskell2010
   hs-source-dirs: test
   main-is: Main.hs
-  other-modules: Common, Lazy, Utils
+  other-modules: AbsValueRange, Common, Lazy, Utils
   ghc-options: -Wall -Wcompat -threaded
   build-depends:
     base,

--- a/symbolic/src/Data/Macaw/Symbolic.hs
+++ b/symbolic/src/Data/Macaw/Symbolic.hs
@@ -193,8 +193,8 @@ import           System.IO (stdout)
 import qualified Lang.Crucible.LLVM.MemModel as MM
 import           Lang.Crucible.LLVM.Intrinsics (llvmIntrinsicTypes)
 
-import qualified Data.Macaw.CFG.Block as M
 import qualified Data.Macaw.CFG as M
+import qualified Data.Macaw.CFG.Block as M
 import qualified Data.Macaw.Discovery.State as M
 import qualified Data.Macaw.Types as M
 
@@ -1031,6 +1031,9 @@ evalMacawExprExtension bak _iTypes _logFn _cst f e0 =
     MacawBitcast xExpr eqPr -> do
       x <- f xExpr
       doBitcast bak x eqPr
+    MacawNarrowBVDomain w dom xExpr -> do
+      ptr <- f xExpr
+      narrowBVDomain sym w dom ptr
 
 -- | A use of a pointer in a memory operation
 --

--- a/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
@@ -1829,29 +1829,34 @@ absValueToBVRange ::
   M.MemWidth w =>
   NatRepr n ->
   MA.AbsValue w (M.BVType n) ->
-  Maybe (Integer, Integer)
+  Maybe (BV.BV n, BV.BV n)
 absValueToBVRange w av =
   case av of
     MA.FinSet s | not (Set.null s) ->
-      checkRange (Set.findMin s, Set.findMax s)
+      checkRange (Set.findMin s) (Set.findMax s)
     MA.StridedInterval si | MASI.size si > 0 ->
-      checkRange (MASI.base si, MASI.intervalEnd si)
+      checkRange (MASI.base si) (MASI.intervalEnd si)
     MA.SubValue (n' :: NatRepr n') innerAv
       | Just (lo, hi) <- absValueToBVRange n' innerAv ->
-          checkRange (liftInnerRange w n' lo hi)
+          let (loLifted, hiLifted) = liftInnerRange w n' lo hi
+          in Just (loLifted, hiLifted)
     _ -> Nothing
   where
-    checkRange r@(lo, hi)
-      | lo < 0 || hi > maxBnd || lo > hi =
-          MSP.panic
-            MSP.Symbolic
-            "absValueToBVRange"
-            [ "AbsValue bounds outside declared bitvector width"
-            , "width: " ++ show w
-            , "bounds: " ++ show r
-            ]
-      | otherwise = Just r
-    maxBnd = 2 ^ natValue w - 1
+    checkRange lo hi =
+      let loBV = BV.mkBV w lo
+          hiBV = BV.mkBV w hi
+          -- Check: lo < 0 (must check as Integer before constructing BV)
+          -- Check: hi > maxUnsigned w becomes: maxUnsigned w < hi
+          -- Check: lo > hi becomes: hi < lo
+      in if lo < 0 || BV.maxUnsigned w `BV.ult` hiBV || hiBV `BV.ult` loBV
+         then MSP.panic
+                MSP.Symbolic
+                "absValueToBVRange"
+                [ "AbsValue bounds outside declared bitvector width"
+                , "width: " ++ show w
+                , "bounds: [" ++ show lo ++ ", " ++ show hi ++ "]"
+                ]
+         else Just (loBV, hiBV)
 
 -- | Given that the lower @u@ bits of a @w@-bit value lie in @[lo, hi]@,
 -- compute the range of the full @w@-bit value.
@@ -1865,19 +1870,26 @@ absValueToBVRange w av =
 liftInnerRange ::
   NatRepr w ->
   NatRepr u ->
-  Integer -> Integer ->
-  (Integer, Integer)
-liftInnerRange w u lo hi = (lo, hi + 2 ^ natValue w - 2 ^ natValue u)
+  BV.BV u -> BV.BV u ->
+  (BV.BV w, BV.BV w)
+liftInnerRange w u lo hi =
+  let loW = BV.zresize w lo
+      hiW = BV.zresize w hi
+      maxU = BV.zresize w (BV.maxUnsigned u)
+      adjustment = BV.sub w (BV.maxUnsigned w) maxU
+      hiResult = BV.add w hiW adjustment
+  in (loW, hiResult)
 
 -- | Extract an unsigned arithmetic range @(lo, hi)@ from a 'Jmp.SubRange'.
 subRangeToBVRange ::
   NatRepr w ->
   Jmp.SubRange (M.BVType w) ->
-  (Integer, Integer)
+  (BV.BV w, BV.BV w)
 subRangeToBVRange w (Jmp.SubRange rp) =
-  liftInnerRange w (Jmp.rangeWidth rp)
-    (toInteger (Jmp.rangeLowerBound rp))
-    (toInteger (Jmp.rangeUpperBound rp))
+  let u = Jmp.rangeWidth rp
+      lo = BV.mkBV u (toInteger (Jmp.rangeLowerBound rp))
+      hi = BV.mkBV u (toInteger (Jmp.rangeUpperBound rp))
+  in liftInnerRange w u lo hi
 
 -- | Emit 'MacawNarrowBVDomain' expressions for each register in the block's
 -- pre-state that has a non-trivial range, drawing from both the
@@ -1937,10 +1949,10 @@ addAbsValueNarrowingForBlock absSt jumpBounds = do
           (Nothing, Just r) -> Just r
           (Nothing, Nothing) -> Nothing
         guard (lo /= hi)
-        guard (lo /= 0 || hi /= 2 ^ natValue w - 1)
+        guard (lo /= BV.zero w || hi /= BV.maxUnsigned w)
         Just $ do
           orig <- crucibleValue (C.GetStruct startStruct crucIdx repr)
-          narrowed <- evalMacawExt (MacawNarrowBVDomain w' (WUB.range w' lo hi) orig)
+          narrowed <- evalMacawExt (MacawNarrowBVDomain w' (WUB.range w' (BV.asUnsigned lo) (BV.asUnsigned hi)) orig)
           pure (Pair crucIdx narrowed : acc)
 
 addParsedBlock :: forall arch ids s

--- a/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/CrucGen.hs
@@ -81,9 +81,11 @@ module Data.Macaw.Symbolic.CrucGen
   , evalAtom
   , crucibleValue
   , freshValueIndex
+  , addAbsValueNarrowingForBlock
+  , absValueToBVRange
   ) where
 
-import           Control.Monad (foldM, forM, unless)
+import           Control.Monad (foldM, forM, guard, unless)
 import           Control.Monad.Except (MonadError(..), ExceptT, runExceptT)
 import qualified Control.Monad.Fail as MF
 import           Control.Monad.State.Strict (MonadState(..), StateT(..), gets, modify')
@@ -92,9 +94,14 @@ import qualified Data.BitVector.Sized as BV
 import qualified Data.Foldable as F
 import           Data.Functor (void, (<&>))
 import qualified Data.Kind as K
+import qualified Data.Macaw.AbsDomain.AbsState as MA
+import qualified Data.Macaw.AbsDomain.JumpBounds as Jmp
+import qualified Data.Macaw.AbsDomain.StackAnalysis as MAS
+import qualified Data.Macaw.AbsDomain.StridedInterval as MASI
 import qualified Data.Macaw.CFG as M
 import qualified Data.Macaw.CFG.Block as M
 import qualified Data.Macaw.Discovery.State as M
+import qualified Data.Macaw.Symbolic.Panic as MSP
 import qualified Data.Macaw.Types as M
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -121,6 +128,7 @@ import           Prettyprinter hiding (width)
 
 import           What4.ProgramLoc as C
 import qualified What4.Symbol as C
+import qualified What4.Domains.BV as WUB
 import qualified What4.Utils.StringLiteral as C
 
 import qualified Lang.Crucible.CFG.Expr as C
@@ -243,6 +251,31 @@ data MacawExprExtension (arch :: K.Type)
   MacawBitcast :: !(f (ToCrucibleType i))
                -> !(M.WidthEqProof i o)
                -> MacawExprExtension arch f (ToCrucibleType o)
+
+  -- | Narrow the abstract domain of a pointer's offset by intersecting it with
+  -- an externally supplied 'WUB.BVDomain'. Sourced from Macaw's discovery-time
+  -- abstract interpretation, this conveys static bounds that are not deducible
+  -- from the What4 bitvector expression alone (e.g. bounds derived from path
+  -- conditions or jump-bound analysis).
+  --
+  -- The wrapped pointer's semantic value is unchanged: the block ID is
+  -- preserved, and the offset's existing abstract domain is met with the
+  -- supplied one. If the meet is no tighter than the existing domain, the
+  -- offset is left unchanged.
+  --
+  -- This is unsafe in the same sense that
+  -- 'What4.Interface.unsafeSetAbstractValue' is: if the supplied domain does
+  -- not actually contain every possible value of the wrapped offset, downstream
+  -- reasoning becomes unsound. Producers must therefore only emit this when the
+  -- bounds come from a sound static analysis.
+  MacawNarrowBVDomain
+    :: (1 <= w)
+    => !(NatRepr w)
+    -- ^ Pointer width
+    -> !(WUB.BVDomain w)
+    -- ^ Externally supplied bounds on the offset
+    -> !(f (MM.LLVMPointerType w))
+    -> MacawExprExtension arch f (MM.LLVMPointerType w)
 
 -- | Extra extension statements required for Crucible to simulate Macaw programs
 --
@@ -586,6 +619,8 @@ instance C.PrettyApp (MacawExprExtension arch) where
 
       MacawNullPtr _ -> sexpr "null_ptr" []
       MacawBitcast x p -> sexpr "bitcast" [f x, viaShow (M.widthEqTarget p)]
+      MacawNarrowBVDomain w dom x ->
+        sexpr ("narrow_bv_domain_" ++ show w) [viaShow dom, f x]
 
 addrWidthIsPos :: M.AddrWidthRepr w -> LeqProof 1 w
 addrWidthIsPos M.Addr32 = LeqProof
@@ -599,6 +634,7 @@ instance C.TypeApp (MacawExprExtension arch) where
       BitsToPtr w _     -> MM.LLVMPointerRepr w
       MacawNullPtr w | LeqProof <- addrWidthIsPos w -> MM.LLVMPointerRepr (M.addrWidthNatRepr w)
       MacawBitcast _ p -> typeToCrucible (M.widthEqTarget p)
+      MacawNarrowBVDomain w _ _ -> MM.LLVMPointerRepr w
 
 
 ------------------------------------------------------------------------
@@ -1785,6 +1821,128 @@ addRegUpdateForBlock startAddr = do
   regStruct <- evalAtom (CR.ReadReg regReg)
   void $ evalMacawStmt $ MacawBlockRegState (M.segoffAddr startAddr) regStruct
 
+-- | Project a Macaw 'MA.AbsValue' to an unsigned arithmetic range
+-- @(lo, hi)@, if it carries enough information to do so. Returns
+-- 'Nothing' for 'MA.TopV', 'MA.SomeStackOffset', and other values
+-- that don't correspond to a bounded set of bitvectors.
+absValueToBVRange ::
+  M.MemWidth w =>
+  NatRepr n ->
+  MA.AbsValue w (M.BVType n) ->
+  Maybe (Integer, Integer)
+absValueToBVRange w av =
+  case av of
+    MA.FinSet s | not (Set.null s) ->
+      checkRange (Set.findMin s, Set.findMax s)
+    MA.StridedInterval si | MASI.size si > 0 ->
+      checkRange (MASI.base si, MASI.intervalEnd si)
+    MA.SubValue (n' :: NatRepr n') innerAv
+      | Just (lo, hi) <- absValueToBVRange n' innerAv ->
+          checkRange (liftInnerRange w n' lo hi)
+    _ -> Nothing
+  where
+    checkRange r@(lo, hi)
+      | lo < 0 || hi > maxBnd || lo > hi =
+          MSP.panic
+            MSP.Symbolic
+            "absValueToBVRange"
+            [ "AbsValue bounds outside declared bitvector width"
+            , "width: " ++ show w
+            , "bounds: " ++ show r
+            ]
+      | otherwise = Just r
+    maxBnd = 2 ^ natValue w - 1
+
+-- | Given that the lower @u@ bits of a @w@-bit value lie in @[lo, hi]@,
+-- compute the range of the full @w@-bit value.
+--
+-- Any concrete @w@-bit value @v@ decomposes as
+--   @v = upper * 2^u + lower@,
+-- where @lower ∈ [lo, hi]@ and @upper ∈ [0, 2^(w-u) - 1]@ is unconstrained.
+-- @v@ is minimised at @lower = lo, upper = 0@, giving @lo@.
+-- @v@ is maximised at @lower = hi, upper = 2^(w-u) - 1@, giving
+--   @hi + (2^(w-u) - 1) * 2^u = hi + 2^w - 2^u@.
+liftInnerRange ::
+  NatRepr w ->
+  NatRepr u ->
+  Integer -> Integer ->
+  (Integer, Integer)
+liftInnerRange w u lo hi = (lo, hi + 2 ^ natValue w - 2 ^ natValue u)
+
+-- | Extract an unsigned arithmetic range @(lo, hi)@ from a 'Jmp.SubRange'.
+subRangeToBVRange ::
+  NatRepr w ->
+  Jmp.SubRange (M.BVType w) ->
+  (Integer, Integer)
+subRangeToBVRange w (Jmp.SubRange rp) =
+  liftInnerRange w (Jmp.rangeWidth rp)
+    (toInteger (Jmp.rangeLowerBound rp))
+    (toInteger (Jmp.rangeUpperBound rp))
+
+-- | Emit 'MacawNarrowBVDomain' expressions for each register in the block's
+-- pre-state that has a non-trivial range, drawing from both the
+-- 'MA.AbsBlockState' and the 'Jmp.InitJumpBounds'.
+addAbsValueNarrowingForBlock ::
+  forall arch ids s.
+  ( M.RegisterInfo (M.ArchReg arch)
+  , M.MemWidth (M.RegAddrWidth (M.ArchReg arch))
+  ) =>
+  MA.AbsBlockState (M.ArchReg arch) ->
+  Jmp.InitJumpBounds arch ->
+  CrucGen arch ids s ()
+addAbsValueNarrowingForBlock absSt jumpBounds = do
+  archFns <- gets translateFns
+  idxMap <- gets crucRegIndexMap
+  let regs   = absSt ^. MA.absRegState
+  let rngMap = Jmp.initRngPredMap jumpBounds
+  let tps    = crucArchRegTypes archFns
+  regReg <- gets crucRegisterReg
+  startStruct <- evalAtom (CR.ReadReg regReg)
+  updates <-
+    MapF.foldlMWithKey
+      (collect tps (M.regStateMap regs) rngMap startStruct)
+      []
+      idxMap
+  unless (Prelude.null updates) $ do
+    newRegStruct <-
+      foldM (\vals (Pair idx val) -> crucibleValue $ C.SetStruct tps vals idx val)
+            startStruct
+            updates
+    setMachineRegs newRegStruct
+  where
+    collect ::
+      Ctx.Assignment C.TypeRepr (MacawCrucibleRegTypes arch) ->
+      MapF.MapF (M.ArchReg arch) (MA.AbsValue (M.RegAddrWidth (M.ArchReg arch))) ->
+      MAS.LocMap (M.ArchReg arch) Jmp.SubRange ->
+      CR.Atom s (ArchRegStruct arch) ->
+      [Pair (Ctx.Index (MacawCrucibleRegTypes arch)) (CR.Atom s)] ->
+      M.ArchReg arch tp ->
+      IndexPair (ArchRegContext arch) tp ->
+      CrucGen arch ids s
+        [Pair (Ctx.Index (MacawCrucibleRegTypes arch)) (CR.Atom s)]
+    collect tps regMap rngMap startStruct acc reg (IndexPair _ crucIdx) =
+      fromMaybe (pure acc) $ do
+        M.BVTypeRepr w <- Just (M.typeRepr reg)
+        LeqProof <- testLeq (knownNat @1) w
+        repr@(MM.LLVMPointerRepr w') <- Just (tps Ctx.! crucIdx)
+        Refl <- testEquality w w'
+        let absRange = do
+              av <- MapF.lookup reg regMap
+              absValueToBVRange w av
+            jmpRange = subRangeToBVRange w <$>
+              MAS.locLookup (MAS.RegLoc reg) rngMap
+        (lo, hi) <- case (jmpRange, absRange) of
+          (Just (jlo, jhi), Just (alo, ahi)) -> Just (max jlo alo, min jhi ahi)
+          (Just r, Nothing) -> Just r
+          (Nothing, Just r) -> Just r
+          (Nothing, Nothing) -> Nothing
+        guard (lo /= hi)
+        guard (lo /= 0 || hi /= 2 ^ natValue w - 1)
+        Just $ do
+          orig <- crucibleValue (C.GetStruct startStruct crucIdx repr)
+          narrowed <- evalMacawExt (MacawNarrowBVDomain w' (WUB.range w' lo hi) orig)
+          pure (Pair crucIdx narrowed : acc)
+
 addParsedBlock :: forall arch ids s
                .  MacawSymbolicArchFunctions arch
                -> BlockLabelMap arch s
@@ -1815,6 +1973,9 @@ addParsedBlock archFns blockLabelMap externalResolutions posFn regReg macawBlock
   (b,bs) <-
     runCrucGen archFns thisPosFn lbl regReg $ do
       addRegUpdateForBlock startAddr
+      addAbsValueNarrowingForBlock
+        (M.blockAbstractState macawBlock)
+        (M.blockJumpBounds macawBlock)
       mapM_ (addMacawStmt startAddr) (M.pblockStmts  macawBlock)
       addMacawParsedTermStmt blockLabelMap externalResolutions startAddr (M.pblockTermStmt macawBlock)
   pure (reverse (b : bs))

--- a/symbolic/src/Data/Macaw/Symbolic/Internal.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Internal.hs
@@ -5,10 +5,13 @@
 -- API, they are exported only for the sake of the test suite.
 module Data.Macaw.Symbolic.Internal
   ( assertionsEnabled
+  , absValueToBVRange
   ) where
 
 import qualified Control.Exception as X
 import           Data.Functor ((<&>))
+
+import           Data.Macaw.Symbolic.CrucGen (absValueToBVRange)
 
 -- | Check if assertions are enabled.
 --

--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -33,6 +33,7 @@ module Data.Macaw.Symbolic.MemOps
   , doLookupFunctionHandle
   , doPtrToBits
   , narrowBVDomain
+  , narrowBVDomainChecked
   , getMem
   , setMem
   , tryGlobPtr
@@ -80,7 +81,7 @@ import           Lang.Crucible.Simulator.GlobalState (lookupGlobal,insertGlobal)
 import           Lang.Crucible.Simulator.Intrinsics (GetIntrinsic, Intrinsic)
 import           Lang.Crucible.Simulator.RegMap (RegEntry,regValue)
 import           Lang.Crucible.Simulator.RegValue (RegValue)
-import           Lang.Crucible.Simulator.SimError (SimErrorReason(AssertFailureSimError))
+import           Lang.Crucible.Simulator.SimError (SimError(..), SimErrorReason(AssertFailureSimError))
 import           Lang.Crucible.Types
 
 import           Lang.Crucible.LLVM.MemModel
@@ -393,6 +394,32 @@ narrowBVDomain sym w dom ptr@(Mem.LLVMPointer base off) = do
       else do
         (_, off') <- annotateTerm sym (unsafeSetAbstractValue dom' off)
         pure (Mem.LLVMPointer base off')
+
+-- | Like 'narrowBVDomain', but also adds a proof obligation that the
+-- offset lies within the unsigned bounds of @dom@. Useful in tests to
+-- catch unsoundness in the discovery-time abstract domain by routing
+-- the narrowing through an SMT solver.
+narrowBVDomainChecked ::
+  (IsSymBackend sym bak, 1 <= w) =>
+  bak ->
+  NatRepr w ->
+  WUB.BVDomain w ->
+  LLVMPtr sym w ->
+  IO (LLVMPtr sym w)
+narrowBVDomainChecked bak w dom ptr@(Mem.LLVMPointer _ off) = do
+  let sym = backendGetSym bak
+  let (lo, hi) = WUB.ubounds dom
+  loBV <- bvLit sym w (BV.mkBV w lo)
+  hiBV <- bvLit sym w (BV.mkBV w hi)
+  loOk <- bvUle sym loBV off
+  hiOk <- bvUle sym off hiBV
+  inRange <- andPred sym loOk hiOk
+  loc <- getCurrentProgramLoc sym
+  let err = AssertFailureSimError
+              "narrowBVDomainChecked: offset outside abstract domain bounds"
+              ("range: [" ++ show lo ++ ", " ++ show hi ++ "]")
+  addAssertion bak (LabeledPred inRange (SimError loc err))
+  narrowBVDomain sym w dom ptr
 
 -- | The state extension for Crucible holding Macaw-specific state for
 -- @macaw-symbolic@'s default memory model.

--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -32,6 +32,7 @@ module Data.Macaw.Symbolic.MemOps
   , doGetGlobal
   , doLookupFunctionHandle
   , doPtrToBits
+  , narrowBVDomain
   , getMem
   , setMem
   , tryGlobPtr
@@ -63,6 +64,9 @@ import qualified Data.Parameterized.Context as Ctx
 
 
 import           What4.Interface
+import qualified What4.ProgramLoc as WPL
+import           What4.Utils.AbstractDomains (getAbsValue)
+import qualified What4.Domains.BV as WUB
 
 import           Lang.Crucible.Backend
 import           Lang.Crucible.CFG.Common (GlobalVar)
@@ -89,10 +93,11 @@ import qualified Lang.Crucible.LLVM.MemModel.Generic as Mem.G
 import           Lang.Crucible.LLVM.DataLayout (Alignment, EndianForm(..), noAlignment, exponentToAlignment)
 import           Lang.Crucible.LLVM.Bytes (Bytes(..))
 
-import           Data.Macaw.Symbolic.CrucGen (addrWidthIsPos, ArchRegStruct, MacawExt, MacawCrucibleRegTypes)
-import           Data.Macaw.Symbolic.PersistentState (ToCrucibleType)
-import           Data.Macaw.CFG.Core (MemRepr(..))
 import qualified Data.Macaw.CFG as M
+import           Data.Macaw.CFG.Core (MemRepr(..))
+import           Data.Macaw.Symbolic.CrucGen (addrWidthIsPos, ArchRegStruct, MacawExt, MacawCrucibleRegTypes)
+import qualified Data.Macaw.Symbolic.Panic as MSP
+import           Data.Macaw.Symbolic.PersistentState (ToCrucibleType)
 
 infix 0 ~>
 
@@ -357,6 +362,37 @@ doPtrToBits sym (Mem.LLVMPointer base off) =
   do undef <- mkUndefinedBV sym "ptr_to_bits" (bvWidth off)
      notPtr <- natEq sym base =<< natLit sym 0
      bvIte sym notPtr off undef
+
+-- | Narrow the abstract domain of a pointer's offset by meeting it with the
+-- supplied 'WUB.BVDomain'. See 'MacawNarrowBVDomain' for details.
+narrowBVDomain ::
+  (IsSymInterface sym, 1 <= w) =>
+  sym ->
+  NatRepr w ->
+  WUB.BVDomain w ->
+  LLVMPtr sym w ->
+  IO (LLVMPtr sym w)
+narrowBVDomain sym w dom ptr@(Mem.LLVMPointer base off) = do
+  let existing = getAbsValue off
+  let dom' = WUB.meet dom existing
+  if WUB.isBottom dom'
+    then do
+      loc <- getCurrentProgramLoc sym
+      MSP.panic
+        MSP.Symbolic
+        "narrowBVDomain"
+        [ "Unsoundness! Abstract values are disjoint!"
+        , "width: " ++ show w
+        , "supplied: " ++ show dom
+        , "existing: " ++ show existing
+        , "location: " ++ show (WPL.plSourceLoc loc)
+        , "function: " ++ show (WPL.plFunction loc)
+        ]
+    else if dom' == existing
+      then pure ptr
+      else do
+        (_, off') <- annotateTerm sym (unsafeSetAbstractValue dom' off)
+        pure (Mem.LLVMPointer base off')
 
 -- | The state extension for Crucible holding Macaw-specific state for
 -- @macaw-symbolic@'s default memory model.

--- a/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/MemOps.hs
@@ -366,6 +366,14 @@ doPtrToBits sym (Mem.LLVMPointer base off) =
 
 -- | Narrow the abstract domain of a pointer's offset by meeting it with the
 -- supplied 'WUB.BVDomain'. See 'MacawNarrowBVDomain' for details.
+--
+-- Panics if the domains are disjoint. This would likely indicate a soundness
+-- bug in Macaw\'s abstract interpretation. If this happens, downstream
+-- consumers can simply switch out 'narrowBVDomain' for an operation that just
+-- ignores 'MacawNarrowBVDomain' statements.
+--
+-- See 'narrowBVDomainChecked' for a version that does a more rigorous soundness
+-- check using an SMT solver.
 narrowBVDomain ::
   (IsSymInterface sym, 1 <= w) =>
   sym ->
@@ -395,10 +403,10 @@ narrowBVDomain sym w dom ptr@(Mem.LLVMPointer base off) = do
         (_, off') <- annotateTerm sym (unsafeSetAbstractValue dom' off)
         pure (Mem.LLVMPointer base off')
 
--- | Like 'narrowBVDomain', but also adds a proof obligation that the
--- offset lies within the unsigned bounds of @dom@. Useful in tests to
--- catch unsoundness in the discovery-time abstract domain by routing
--- the narrowing through an SMT solver.
+-- | Like 'narrowBVDomain', but also adds a proof obligation that the offset
+-- lies within the unsigned bounds of the 'WUB.BVDomain'. Useful in tests
+-- to catch unsoundness in the discovery-time abstract domain by routing the
+-- narrowing through an SMT solver.
 narrowBVDomainChecked ::
   (IsSymBackend sym bak, 1 <= w) =>
   bak ->

--- a/symbolic/src/Data/Macaw/Symbolic/Testing.hs
+++ b/symbolic/src/Data/Macaw/Symbolic/Testing.hs
@@ -62,6 +62,7 @@ import qualified Data.Macaw.Memory.ElfLoader.PLTStubs as MELP
 import qualified Data.Macaw.Memory.LoadCommon as MML
 import qualified Data.Macaw.Symbolic as MS
 import qualified Data.Macaw.Symbolic.CrucGen as MSC
+import qualified Data.Macaw.Symbolic.MemOps as MSMO
 import qualified Data.Macaw.Symbolic.Memory as MSM
 import qualified Data.Macaw.Symbolic.Memory.Common as MSMC
 import qualified Data.Macaw.Symbolic.Memory.Lazy as MSMLazy
@@ -112,6 +113,23 @@ data TestingException = ELFResolutionError String
   deriving (Show)
 
 instance X.Exception TestingException
+
+-- | Override 'MacawNarrowBVDomain' evaluation to use 'narrowBVDomainChecked',
+-- which adds an SMT proof obligation that the offset lies within the supplied
+-- bounds. This catches unsoundness in the discovery-time abstract domain when
+-- proof obligations are discharged (e.g. by 'simulateAndVerify').
+withCheckedNarrowBVDomain ::
+  CS.ExtensionImpl p sym (MS.MacawExt arch) ->
+  CS.ExtensionImpl p sym (MS.MacawExt arch)
+withCheckedNarrowBVDomain extImpl =
+  extImpl
+    { CS.extensionEval = \bak iTypes logFn cst f e ->
+        case e of
+          MSC.MacawNarrowBVDomain w dom xExpr -> do
+            ptr <- f xExpr
+            MSMO.narrowBVDomainChecked bak w dom ptr
+          _ -> CS.extensionEval extImpl bak iTypes logFn cst f e
+    }
 
 -- | Convert machine addresses into Crucible positions.
 --
@@ -675,7 +693,7 @@ simDiscoveredFunction bak execFeatures archVals halloc iMem regs binfo dfi = do
   memVar <- CLM.mkMemVar "macaw-symbolic:test-harness:llvm_memory" halloc
   extImpl <-
     MS.withArchEval archVals sym $ \archEvalFn ->
-      pure (MS.macawExtensions archEvalFn memVar mmConf)
+      pure (withCheckedNarrowBVDomain (MS.macawExtensions archEvalFn memVar mmConf))
 
   let funName = functionName dfi
   let mainInfo = mainBinaryInfo binfo

--- a/symbolic/test/AbsValueRange.hs
+++ b/symbolic/test/AbsValueRange.hs
@@ -107,7 +107,7 @@ genAbsValWithConcreteAt w = Gen.choice $
 -- | Generate a BV width in [1, 64] then an abstract value at that width.
 genAbsValWithConcrete :: H.Gen AbsValWithConcrete
 genAbsValWithConcrete = do
-  nraw <- Gen.integral (Range.linear 1 64)
+  nraw <- Gen.integral (Range.linear (1 :: Integer) 64)
   case someNat nraw of
     Just (Some w) | Just LeqProof <- isPosNat w -> genAbsValWithConcreteAt w
     _ -> Gen.discard

--- a/symbolic/test/AbsValueRange.hs
+++ b/symbolic/test/AbsValueRange.hs
@@ -9,6 +9,7 @@
 module AbsValueRange (tests) where
 
 import           Data.Bits ((.&.))
+import qualified Data.BitVector.Sized as BV
 import qualified Data.Set as Set
 
 import qualified Data.Macaw.AbsDomain.AbsState as MA
@@ -141,9 +142,10 @@ prop_absValueToBVRangeSound =
     case absValueToBVRange w av of
       Nothing -> H.discard
       Just (lo, hi) -> do
-        H.footnote $ "range: [" ++ show lo ++ ", " ++ show hi ++ "]"
+        H.footnote $ "range: [" ++ show (BV.asUnsigned lo) ++ ", " ++ show (BV.asUnsigned hi) ++ "]"
         H.footnote $ "concrete value: " ++ show concreteVal
-        H.assert (lo <= concreteVal && concreteVal <= hi)
+        let concreteValBV = BV.mkBV w concreteVal
+        H.assert (lo `BV.ule` concreteValBV && concreteValBV `BV.ule` hi)
 
 ------------------------------------------------------------------------
 -- Test tree

--- a/symbolic/test/AbsValueRange.hs
+++ b/symbolic/test/AbsValueRange.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module AbsValueRange (tests) where
+
+import           Data.Bits ((.&.))
+import qualified Data.Set as Set
+
+import qualified Data.Macaw.AbsDomain.AbsState as MA
+import qualified Data.Macaw.AbsDomain.StridedInterval as MASI
+import           Data.Macaw.Symbolic.Internal (absValueToBVRange)
+import           Data.Macaw.Types (BVType)
+import           Data.Parameterized.NatRepr
+                   ( NatRepr, natValue, someNat
+                   , LeqProof(..), isPosNat, testLeq, addNat, knownNat
+                   )
+import           Data.Parameterized.Some (Some(..))
+
+import qualified Hedgehog as H
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.Hedgehog (testPropertyNamed)
+
+------------------------------------------------------------------------
+-- Types
+------------------------------------------------------------------------
+
+-- | An abstract value at some 'BVType n' (pointer width 64) together
+-- with a concrete integer that belongs to the abstract set, and the
+-- 'NatRepr n' needed to call 'absValueToBVRange'.
+data AbsValWithConcrete where
+  AbsValWithConcrete ::
+    NatRepr n ->
+    MA.AbsValue 64 (BVType n) ->
+    Integer ->
+    AbsValWithConcrete
+
+instance Show AbsValWithConcrete where
+  show (AbsValWithConcrete w av v) =
+    show (MA.ppAbsValue av) ++ " contains " ++ show v
+      ++ " (width " ++ show (natValue w) ++ ")"
+
+------------------------------------------------------------------------
+-- Sub-generators
+------------------------------------------------------------------------
+
+-- | Generate a FinSet abstract value at width @n@ with a concrete member.
+genFinSet :: NatRepr n -> H.Gen AbsValWithConcrete
+genFinSet w = do
+  let maxVal = 2 ^ natValue w - 1 :: Integer
+  vals <- Gen.list (Range.linear 1 8)
+            (Gen.integral (Range.linear 0 maxVal))
+  let s = Set.fromList vals
+  v <- Gen.element (Set.toList s)
+  pure (AbsValWithConcrete w (MA.FinSet s) v)
+
+-- | Generate a StridedInterval abstract value at width @n@ with a concrete member.
+genStridedInterval :: NatRepr n -> H.Gen AbsValWithConcrete
+genStridedInterval w = do
+  let maxVal = 2 ^ natValue w - 1 :: Integer
+  b      <- Gen.integral (Range.linear 0 (maxVal - 1))
+  stride <- Gen.integral (Range.linear 1 (maxVal - b))
+  let maxSteps = (maxVal - b) `div` stride
+  numSteps <- Gen.integral (Range.linear 0 maxSteps)
+  let si = MASI.StridedInterval
+             { MASI.typ    = w
+             , MASI.base   = b
+             , MASI.range  = numSteps
+             , MASI.stride = stride
+             }
+  step <- Gen.integral (Range.linear 0 numSteps)
+  pure (AbsValWithConcrete w (MA.StridedInterval si) (b + step * stride))
+
+genSubValue :: NatRepr n -> H.Gen AbsValWithConcrete
+genSubValue w = do
+  let maxVal = 2 ^ natValue w - 1 :: Integer
+  n'raw <- Gen.integral (Range.linear 1 (natValue w - 1))
+  case someNat n'raw of
+    Just (Some innerW)
+      | Just LeqProof <- isPosNat innerW
+      , Just LeqProof <- testLeq (addNat innerW (knownNat @1)) w -> do
+          AbsValWithConcrete innerW' innerAv innerV <- genAbsValWithConcreteAt innerW
+          case testLeq (addNat innerW' (knownNat @1)) w of
+            Just LeqProof -> do
+              upperBits <- Gen.integral
+                             (Range.linear 0 (maxVal `div` (2 ^ natValue innerW')))
+              let v = upperBits * 2 ^ natValue innerW' + innerV
+              pure (AbsValWithConcrete w (MA.SubValue innerW' innerAv) v)
+            Nothing -> Gen.discard
+    _ -> Gen.discard
+
+-- | Generate an abstract value at a given width together with a concrete member.
+genAbsValWithConcreteAt :: NatRepr n -> H.Gen AbsValWithConcrete
+genAbsValWithConcreteAt w = Gen.choice $
+  [ genFinSet w
+  , genStridedInterval w
+  ]
+  -- SubValue requires at least 2 bits (needs a strictly smaller inner width).
+  ++ [ genSubValue w | natValue w >= 2 ]
+
+-- | Generate a BV width in [1, 64] then an abstract value at that width.
+genAbsValWithConcrete :: H.Gen AbsValWithConcrete
+genAbsValWithConcrete = do
+  nraw <- Gen.integral (Range.linear 1 64)
+  case someNat nraw of
+    Just (Some w) | Just LeqProof <- isPosNat w -> genAbsValWithConcreteAt w
+    _ -> Gen.discard
+
+------------------------------------------------------------------------
+-- Properties
+------------------------------------------------------------------------
+
+-- | Membership check matching 'MA.mayBeMember' for the forms we generate.
+isMember :: Integer -> MA.AbsValue 64 (BVType n) -> Bool
+isMember v = \case
+  MA.FinSet s -> Set.member v s
+  MA.StridedInterval si -> MASI.member v si
+  MA.SubValue n' inner -> isMember (v .&. (2 ^ natValue n' - 1)) inner
+  _ -> True
+
+-- | Verify that 'genAbsValWithConcrete' really produces concrete values
+-- that belong to the abstract set it pairs them with.
+prop_generatorProducesMember :: H.Property
+prop_generatorProducesMember =
+  H.withTests 10000 $ H.property $ do
+    AbsValWithConcrete _ av v <- H.forAll genAbsValWithConcrete
+    H.assert (isMember v av)
+
+-- | Soundness: every concrete value drawn from an 'MA.AbsValue' must lie
+-- within the interval returned by 'absValueToBVRange'.
+prop_absValueToBVRangeSound :: H.Property
+prop_absValueToBVRangeSound =
+  H.withTests 10000 $ H.property $ do
+    AbsValWithConcrete w av concreteVal <- H.forAll genAbsValWithConcrete
+    case absValueToBVRange w av of
+      Nothing -> H.discard
+      Just (lo, hi) -> do
+        H.footnote $ "range: [" ++ show lo ++ ", " ++ show hi ++ "]"
+        H.footnote $ "concrete value: " ++ show concreteVal
+        H.assert (lo <= concreteVal && concreteVal <= hi)
+
+------------------------------------------------------------------------
+-- Test tree
+------------------------------------------------------------------------
+
+tests :: TestTree
+tests = testGroup "absValueToBVRange"
+  [ testPropertyNamed
+      "genAbsValWithConcrete produces genuine members"
+      "prop_generatorProducesMember"
+      prop_generatorProducesMember
+  , testPropertyNamed
+      "range covers every concrete value in the abstract set"
+      "prop_absValueToBVRangeSound"
+      prop_absValueToBVRangeSound
+  ]

--- a/symbolic/test/Main.hs
+++ b/symbolic/test/Main.hs
@@ -4,6 +4,7 @@ import Test.Tasty ( defaultMain, testGroup )
 import Test.Tasty.HUnit ( assertBool, testCase )
 
 import Data.Macaw.Symbolic.Internal ( assertionsEnabled )
+import qualified AbsValueRange
 import qualified Common
 import qualified Lazy
 
@@ -15,4 +16,5 @@ main = defaultMain $ testGroup "macaw-symbolic"
       assertBool "assertions should be enabled" assertsEnabled
   , Common.tests
   , Lazy.tests
+  , AbsValueRange.tests
   ]


### PR DESCRIPTION
Modest CFG expansion on the GREASE test suite:

- x86-64: ~2.3%
- ppc32: ~0.2%
- armv7l: ~0.2%

The meet of both analyses really does fire and help.

Fixes #614.